### PR TITLE
Fix stale active sessions persisting after server restart

### DIFF
--- a/ask-forge-web/src/api/index.ts
+++ b/ask-forge-web/src/api/index.ts
@@ -56,6 +56,17 @@ function cleanupSessions() {
 // Run cleanup every 5 minutes
 setInterval(cleanupSessions, 5 * 60 * 1000);
 
+// On startup, mark all "active" sessions as "inactive" since in-memory state is lost on restart
+(function cleanupStaleActiveSessions() {
+	const db = getDb();
+	const result = db.run("UPDATE sessions SET status = 'inactive', ended_at = ? WHERE status = 'active'", [
+		new Date().toISOString(),
+	]);
+	if (result.changes > 0) {
+		console.log(`Marked ${result.changes} stale active session(s) as inactive on startup`);
+	}
+})();
+
 const api = new Hono();
 
 api.get("/health", (c) => {


### PR DESCRIPTION
## Summary

On server startup, mark all sessions with status 'active' as 'inactive'.

## Problem

Session status is stored in the database, but cleanup relies on an in-memory `sessionTimestamps` Map. When the server restarts:
1. The in-memory Map is cleared
2. Sessions marked "active" in the DB are never cleaned up
3. They appear as active in the visualizer indefinitely

## Solution

Add startup cleanup that immediately marks all "active" sessions as "inactive", since no session can actually be active right after a restart (no in-memory state exists yet).

```typescript
// On startup, mark all "active" sessions as "inactive"
db.run("UPDATE sessions SET status = 'inactive', ended_at = ? WHERE status = 'active'", [now]);
```

This is safe because:
- "inactive" just means "not loaded in memory"
- Sessions can always be restored via `/api/restore`
- User messages are persisted immediately, so no data is lost