### PR TITLE
Bump @nilenso/ask-forge to 0.0.2

### DIFF
--- a/ask-forge-web/package.json
+++ b/ask-forge-web/package.json
@@ -21,7 +21,7 @@
 		"typescript": "^5"
 	},
 	"dependencies": {
-		"@nilenso/ask-forge": "npm:@jsr/nilenso__ask-forge",
+		"@nilenso/ask-forge": "npm:@jsr/nilenso__ask-forge@0.0.2",
 		"hono": "^4.7.10",
 		"marked": "^17.0.1",
 		"react": "^19.1.0",


### PR DESCRIPTION
## Summary

Pin `@nilenso/ask-forge` to version 0.0.2.

## Changes

- `"npm:@jsr/nilenso__ask-forge"` → `"npm:@jsr/nilenso__ask-forge@0.0.2"`

## Why

Version 0.0.2 adds `getMessages()` and `replaceMessages()` methods to the Session interface, required for:
- Persisting conversation history to the database
- Restoring sessions with prior context

This fixes the `session.replaceMessages is not a function` error on the hosted server.