### PR TITLE
Use JSR package @nilenso/ask-forge@0.0.2 in Docker build

### DIFF
--- a/.github/workflows/ask-forge-web-docker.yml
+++ b/.github/workflows/ask-forge-web-docker.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - "ask-forge-web/**"
-      - "ask-forge/**"
   workflow_dispatch:
 
 env:
@@ -41,9 +40,6 @@ jobs:
           tags: |
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Copy ask-forge into build context
-        run: cp -r ask-forge ask-forge-web/ask-forge
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/ask-forge-web/Dockerfile
+++ b/ask-forge-web/Dockerfile
@@ -3,16 +3,10 @@ FROM oven/bun:1-alpine AS builder
 
 WORKDIR /app
 
-# Copy ask-forge dependency first (from build context)
-COPY ask-forge ./ask-forge
-
 # Copy package files
 COPY package.json bun.lock ./
 
-# Update local dependency path for Docker context
-RUN sed -i 's|file:../ask-forge|file:./ask-forge|' package.json
-
-# Install dependencies
+# Install dependencies (pulls @nilenso/ask-forge from JSR)
 RUN bun install
 
 # Copy source files
@@ -41,10 +35,8 @@ RUN apk add --no-cache git openssh-client curl ripgrep fd && \
       -o /usr/local/bin/litem8 && \
     chmod +x /usr/local/bin/litem8
 
-# Copy ask-forge dependency and install production dependencies
-COPY ask-forge ./ask-forge
+# Copy package files and node_modules from builder
 COPY package.json bun.lock ./
-RUN sed -i 's|file:../ask-forge|file:./ask-forge|' package.json
 COPY --from=builder /app/node_modules ./node_modules
 
 # Copy built assets and source

--- a/ask-forge-web/package.json
+++ b/ask-forge-web/package.json
@@ -21,7 +21,7 @@
 		"typescript": "^5"
 	},
 	"dependencies": {
-		"@nilenso/ask-forge": "npm:@jsr/nilenso__ask-forge",
+		"@nilenso/ask-forge": "npm:@jsr/nilenso__ask-forge@0.0.2",
 		"hono": "^4.7.10",
 		"marked": "^17.0.1",
 		"react": "^19.1.0",


### PR DESCRIPTION
## Summary

Switch Docker build from bundling local `ask-forge` folder to using the JSR package.

## Changes

### `ask-forge-web/package.json`
- Pin dependency to `@nilenso/ask-forge@0.0.2`

### `ask-forge-web/Dockerfile`
- Remove `COPY ask-forge ./ask-forge` steps
- Remove `sed` command that rewrote the package.json path
- Dependencies now pulled from JSR during `bun install`

### `.github/workflows/ask-forge-web-docker.yml`
- Remove `ask-forge/**` from path triggers
- Remove "Copy ask-forge into build context" step

## Why

The ask-forge library is now published to JSR as `@nilenso/ask-forge`. Version 0.0.2 includes `getMessages()` and `replaceMessages()` methods required for session restore.

This fixes the `session.replaceMessages is not a function` error on the hosted server.