### PR TITLE
Fix Docker build: copy .npmrc to configure JSR registry

### DIFF
--- a/ask-forge-web/Dockerfile
+++ b/ask-forge-web/Dockerfile
@@ -3,8 +3,8 @@ FROM oven/bun:1-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package.json bun.lock ./
+# Copy package files and registry config
+COPY package.json bun.lock .npmrc ./
 
 # Install dependencies (pulls @nilenso/ask-forge from JSR)
 RUN bun install


### PR DESCRIPTION
## Summary

Copy `.npmrc` before `bun install` in Dockerfile to configure the JSR registry.

## Problem

Docker build fails with:
```
error: GET https://registry.npmjs.org/@jsr%2fnilenso__ask-forge - 404
```

Bun doesn't know to look at JSR's npm bridge for `@jsr` scoped packages.

## Solution

The `.npmrc` file contains:
```
@jsr:registry=https://npm.jsr.io
```

This tells bun to fetch `@jsr/*` packages from JSR's npm compatibility layer.