### PR TITLE
feat(visualizer): store and display system prompt per session

### DIFF
--- a/ask-forge-web/migrations/010_add_system_prompt.sql
+++ b/ask-forge-web/migrations/010_add_system_prompt.sql
@@ -1,0 +1,2 @@
+-- Add system_prompt column to sessions table to store the prompt used for each session
+ALTER TABLE sessions ADD COLUMN system_prompt TEXT;

--- a/ask-forge-web/public/visualizer.html
+++ b/ask-forge-web/public/visualizer.html
@@ -474,6 +474,36 @@
 		}
 		.viz-msg-content { line-height: 1.7; color: var(--text-primary); }
 
+		/* System prompt collapsible */
+		.viz-system-prompt {
+			margin-left: 20px; margin-bottom: 4px;
+			background: var(--bg-secondary); border-radius: 8px;
+			border: 1px solid var(--border-subtle);
+			overflow: hidden;
+		}
+		.viz-system-prompt-summary {
+			display: flex; align-items: center; gap: 6px; padding: 8px 12px;
+			font-size: 13px; font-weight: 600; color: var(--text-secondary);
+			cursor: pointer; user-select: none; list-style: none;
+		}
+		.viz-system-prompt-summary::-webkit-details-marker { display: none; }
+		.viz-system-prompt-summary::before {
+			content: "▶"; font-size: 10px; color: var(--text-muted);
+			transition: transform 0.15s ease;
+		}
+		.viz-system-prompt[open] > .viz-system-prompt-summary::before {
+			transform: rotate(90deg);
+		}
+		.viz-system-prompt-summary:hover { background: var(--bg-tertiary); }
+		.viz-system-prompt-icon { color: var(--accent-pink); }
+		.viz-system-prompt-content {
+			padding: 12px 16px; margin: 0 12px 12px 12px;
+			font-family: var(--font-mono); font-size: 12px; line-height: 1.6;
+			color: var(--text-secondary); background: var(--bg-tertiary);
+			border-radius: 6px; white-space: pre-wrap; word-break: break-word;
+			max-height: 400px; overflow-y: auto;
+		}
+
 		/* Tool calls */
 		.viz-tool-calls {
 			display: flex; flex-direction: column; gap: 4px; margin-left: 20px;

--- a/ask-forge-web/src/api/index.ts
+++ b/ask-forge-web/src/api/index.ts
@@ -1,5 +1,13 @@
 import { connect, type Session } from "@nilenso/ask-forge";
 import { Hono } from "hono";
+
+// The SYSTEM_PROMPT is not re-exported from @nilenso/ask-forge's package index,
+// so we read it from the config module at the resolved path.
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import of internal module
+const askForgeConfig: any = await import(
+	import.meta.resolve("@nilenso/ask-forge").replace("/index.js", "/config.js")
+);
+const SYSTEM_PROMPT: string = askForgeConfig.SYSTEM_PROMPT;
 import { createAuthMiddleware, getUserFromContext } from "../lib/auth.ts";
 import {
 	createSession as createDbSession,
@@ -159,6 +167,7 @@ api.post("/connect", createAuthMiddleware(), async (c) => {
 			userId: payload.sub,
 			repositoryId: repository.id,
 			checkoutId: checkout.id,
+			systemPrompt: SYSTEM_PROMPT,
 		});
 
 		const session = wrapSession(rawSession, rawSession.id);

--- a/ask-forge-web/src/client/Visualizer.tsx
+++ b/ask-forge-web/src/client/Visualizer.tsx
@@ -42,6 +42,7 @@ interface SessionLog {
 	endedAt: number;
 	endReason: "active" | "inactive" | "error";
 	error?: string;
+	systemPrompt?: string | null;
 	asks: AskEntry[];
 }
 
@@ -464,6 +465,17 @@ export function Visualizer() {
 									</div>
 									<div className="viz-msg-content">{ask.question}</div>
 								</div>
+
+								{/* System Prompt - collapsible, shown only on first ask */}
+								{index === 0 && session?.systemPrompt && (
+									<details className="viz-system-prompt">
+										<summary className="viz-system-prompt-summary">
+											<span className="viz-system-prompt-icon">⚙</span>
+											System Prompt
+										</summary>
+										<pre className="viz-system-prompt-content">{session.systemPrompt}</pre>
+									</details>
+								)}
 
 								{/* Tool Calls - Each individually collapsible */}
 								{ask.toolCalls.length > 0 && (

--- a/ask-forge-web/src/lib/db.ts
+++ b/ask-forge-web/src/lib/db.ts
@@ -204,6 +204,7 @@ export interface DbSession {
 	status: string;
 	created_at: string;
 	ended_at: string | null;
+	system_prompt: string | null;
 }
 
 export interface DbMessage {
@@ -247,13 +248,22 @@ export function createSession(params: {
 	repositoryId: number;
 	checkoutId?: number | null;
 	title?: string | null;
+	systemPrompt?: string | null;
 }): DbSession {
 	const db = getDb();
 	const now = new Date().toISOString();
 	db.run(
-		`INSERT INTO sessions (id, user_id, repository_id, checkout_id, title, status, created_at)
-		 VALUES (?, ?, ?, ?, ?, 'active', ?)`,
-		[params.id, params.userId, params.repositoryId, params.checkoutId ?? null, params.title ?? null, now],
+		`INSERT INTO sessions (id, user_id, repository_id, checkout_id, title, status, created_at, system_prompt)
+		 VALUES (?, ?, ?, ?, ?, 'active', ?, ?)`,
+		[
+			params.id,
+			params.userId,
+			params.repositoryId,
+			params.checkoutId ?? null,
+			params.title ?? null,
+			now,
+			params.systemPrompt ?? null,
+		],
 	);
 
 	return {
@@ -265,6 +275,7 @@ export function createSession(params: {
 		status: "active",
 		created_at: now,
 		ended_at: null,
+		system_prompt: params.systemPrompt ?? null,
 	};
 }
 

--- a/ask-forge-web/src/visualizer-server.ts
+++ b/ask-forge-web/src/visualizer-server.ts
@@ -71,11 +71,12 @@ app.get("/api/session/:id", (c) => {
 					ended_at: string | null;
 					git_url: string;
 					default_commit: string;
+					system_prompt: string | null;
 				},
 				[string]
 			>(
 				`SELECT s.id, s.title, s.status, s.created_at, s.ended_at,
-				        r.git_url, r.default_commit
+				        s.system_prompt, r.git_url, r.default_commit
 				 FROM sessions s
 				 JOIN repositories r ON s.repository_id = r.id
 				 WHERE s.id = ?`,
@@ -256,6 +257,7 @@ app.get("/api/session/:id", (c) => {
 			startedAt: new Date(session.created_at).getTime(),
 			endedAt: session.ended_at ? new Date(session.ended_at).getTime() : Date.now(),
 			endReason: session.status,
+			systemPrompt: session.system_prompt ?? null,
 			asks,
 		};
 


### PR DESCRIPTION
- Add migration 010 to add system_prompt column to sessions table
- Capture SYSTEM_PROMPT from ask-forge config on session creation
- Include systemPrompt in visualizer API response
- Render collapsible system prompt section in visualizer UI between the first question and tool calls