### PR TITLE
Add Ansible playbooks for ask-forge-web deployment

### DIFF
--- a/.github/workflows/ask-forge-web-docker.yml
+++ b/.github/workflows/ask-forge-web-docker.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "ask-forge-web/**"
+      - "ask-forge-infra/**"
   workflow_dispatch:
 
 env:
@@ -55,18 +56,31 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     environment: prod
+    defaults:
+      run:
+        working-directory: ask-forge-infra
+
     steps:
-      - name: Deploy to server
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ask.nilenso.ai
-          username: root
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script_stop: true
-          script: |
-            set -e
-            cd ~/ask-forge-web
-            docker compose pull
-            docker compose down --remove-orphans || true
-            docker compose up -d
-            docker image prune -f
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Ansible
+        run: |
+          pip install ansible
+
+      - name: Install Ansible collections
+        run: |
+          ansible-galaxy collection install -r requirements.yml
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ask.nilenso.ai >> ~/.ssh/known_hosts
+
+      - name: Run deploy playbook
+        run: |
+          ansible-playbook playbooks/deploy.yml \
+            --private-key ~/.ssh/deploy_key \
+            -e ansible_ssh_common_args='-o StrictHostKeyChecking=accept-new'

--- a/ask-forge-infra/README.md
+++ b/ask-forge-infra/README.md
@@ -1,0 +1,85 @@
+# ask-forge-infra
+
+Ansible playbooks for deploying ask-forge-web.
+
+## Structure
+
+```
+ask-forge-infra/
+├── ansible.cfg           # Ansible configuration
+├── inventory/
+│   └── hosts.yml         # Server inventory
+├── playbooks/
+│   ├── setup.yml         # Initial server setup (run once)
+│   └── deploy.yml        # Deployment (used by CI)
+├── roles/
+│   ├── gvisor/           # Install gVisor runtime
+│   ├── gateway/          # Caddy reverse proxy
+│   └── app/              # ask-forge-web application
+└── requirements.yml      # Ansible Galaxy dependencies
+```
+
+## Prerequisites
+
+```bash
+# Install Ansible
+pip install ansible
+
+# Install required collections
+ansible-galaxy collection install -r requirements.yml
+```
+
+## Usage
+
+### Initial Server Setup
+
+Run once on a new server to install all dependencies:
+
+```bash
+cd ask-forge-infra
+ansible-playbook playbooks/setup.yml
+```
+
+This will:
+- Install Docker
+- Install gVisor (runsc)
+- Set up Caddy as reverse proxy
+- Create app directories and config files
+
+After running, edit `~/ask-forge-web/.env` on the server with your API keys.
+
+### Deployment
+
+Used by CI to deploy new versions:
+
+```bash
+ansible-playbook playbooks/deploy.yml
+```
+
+This will:
+- Pull the latest Docker images
+- Restart containers
+- Clean up old images
+- Verify the app is healthy
+
+### GitHub Actions
+
+The deploy playbook is designed to run from GitHub Actions. It requires:
+- `DEPLOY_SSH_KEY` secret with SSH private key
+- Server must have the public key in `~/.ssh/authorized_keys`
+
+## Verification
+
+After deployment:
+
+```bash
+# Check containers are running
+docker ps
+
+# Test gVisor
+docker run --runtime=runsc --rm hello-world
+
+# Check endpoints
+curl -I https://ask.nilenso.ai
+curl -I https://ask-forge-visualizer.nilenso.ai
+```

--- a/ask-forge-infra/ansible.cfg
+++ b/ask-forge-infra/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+inventory = inventory/hosts.yml
+host_key_checking = False
+retry_files_enabled = False
+gathering = smart
+
+[ssh_connection]
+pipelining = True

--- a/ask-forge-infra/inventory/hosts.yml
+++ b/ask-forge-infra/inventory/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    ask-forge:
+      ansible_host: ask.nilenso.ai
+      ansible_user: root

--- a/ask-forge-infra/playbooks/deploy.yml
+++ b/ask-forge-infra/playbooks/deploy.yml
@@ -1,0 +1,53 @@
+---
+# Deployment playbook for CI/CD
+# Pulls latest images and restarts the application
+#
+# Usage:
+#   ansible-playbook playbooks/deploy.yml
+#
+# From GitHub Actions:
+#   ansible-playbook playbooks/deploy.yml --private-key /path/to/key
+
+- name: Deploy ask-forge-web
+  hosts: ask-forge
+  gather_facts: false
+
+  tasks:
+    - name: Pull latest images
+      community.docker.docker_compose_v2:
+        project_src: ~/ask-forge-web
+        pull: always
+        state: present
+      register: compose_pull
+
+    - name: Stop and remove old containers
+      community.docker.docker_compose_v2:
+        project_src: ~/ask-forge-web
+        state: absent
+        remove_orphans: true
+      when: compose_pull.changed
+
+    - name: Start application
+      community.docker.docker_compose_v2:
+        project_src: ~/ask-forge-web
+        state: present
+
+    - name: Prune old Docker images
+      community.docker.docker_prune:
+        images: true
+        images_filters:
+          dangling: false
+
+    - name: Wait for app to be healthy
+      uri:
+        url: http://localhost:3000/health
+        status_code: 200
+      register: health_check
+      retries: 30
+      delay: 2
+      until: health_check.status == 200
+      ignore_errors: true
+
+    - name: Display deployment result
+      debug:
+        msg: "{{ 'Deployment successful! App is healthy.' if health_check.status == 200 else 'Warning: App may not be healthy yet.' }}"

--- a/ask-forge-infra/playbooks/setup.yml
+++ b/ask-forge-infra/playbooks/setup.yml
@@ -1,0 +1,54 @@
+---
+# Initial server setup playbook
+# Run once to configure a new server with all dependencies
+#
+# Usage:
+#   ansible-playbook playbooks/setup.yml
+#   ansible-playbook playbooks/setup.yml -l ask-forge
+
+- name: Setup ask-forge-web server
+  hosts: ask-forge
+  become: true
+  gather_facts: true
+
+  pre_tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Install Docker (if not present)
+      apt:
+        name:
+          - docker.io
+          - docker-compose-plugin
+        state: present
+
+    - name: Ensure Docker is running
+      systemd:
+        name: docker
+        state: started
+        enabled: true
+
+  roles:
+    - role: gvisor
+      tags: [gvisor]
+    - role: gateway
+      tags: [gateway]
+    - role: app
+      tags: [app]
+
+  post_tasks:
+    - name: Display completion message
+      debug:
+        msg: |
+          ✓ Server setup complete!
+          
+          Next steps:
+          1. Edit ~/ask-forge-web/.env with your API keys
+          2. Run the deploy playbook to start the app
+          
+          Verification commands:
+            docker ps
+            docker run --runtime=runsc --rm hello-world
+            curl -I https://ask.nilenso.ai

--- a/ask-forge-infra/requirements.yml
+++ b/ask-forge-infra/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: community.docker
+    version: ">=3.0.0"

--- a/ask-forge-infra/roles/app/files/docker-compose.yml
+++ b/ask-forge-infra/roles/app/files/docker-compose.yml
@@ -1,0 +1,60 @@
+services:
+  # Sandbox worker: isolated git clone + tool execution
+  # Security: bwrap (filesystem/PID) + seccomp (network blocking) + gVisor (syscall)
+  sandbox:
+    build:
+      context: ../../ask-forge/sandbox
+      dockerfile: Containerfile
+    runtime: runsc  # gVisor required - handles bwrap namespace creation
+    cap_drop:
+      - ALL
+    cap_add:
+      - SYS_ADMIN  # For bwrap namespace creation inside gVisor
+    security_opt:
+      - no-new-privileges
+    tmpfs:
+      - /tmp:rw,size=64m
+    networks:
+      - sandbox
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+    environment:
+      - PORT=8080
+      - SANDBOX_SECRET=${SANDBOX_SECRET}
+    healthcheck:
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:8080/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  web:
+    image: ghcr.io/nilenso/ask-forge-web:latest
+    container_name: ask-forge-web
+    environment:
+      - PORT=3000
+      - VISUALIZER_PORT=3001
+      - DATABASE_PATH=/app/data/ask-forge.db
+      - SESSION_DIR=/app/data/sessions
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+      - SANDBOX_URL=http://sandbox:8080
+      - SANDBOX_SECRET=${SANDBOX_SECRET}
+    volumes:
+      - ./data:/app/data
+    networks:
+      - sandbox
+      - web
+    depends_on:
+      sandbox:
+        condition: service_healthy
+    restart: unless-stopped
+
+networks:
+  sandbox:
+    # Git clone needs outbound access. Tool execution is network-blocked via seccomp.
+    # Security layers: bwrap (filesystem/PID), seccomp (network), gVisor (syscall).
+  web:
+    external: true

--- a/ask-forge-infra/roles/app/handlers/main.yml
+++ b/ask-forge-infra/roles/app/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart app
+  community.docker.docker_compose_v2:
+    project_src: ~/ask-forge-web
+    state: restarted

--- a/ask-forge-infra/roles/app/tasks/main.yml
+++ b/ask-forge-infra/roles/app/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Create app directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - ~/ask-forge-web
+    - ~/ask-forge-web/data
+    - ~/ask-forge-web/data/sessions
+
+- name: Copy docker-compose.yml
+  copy:
+    src: docker-compose.yml
+    dest: ~/ask-forge-web/docker-compose.yml
+  notify: Restart app
+
+- name: Copy .env.example
+  copy:
+    dest: ~/ask-forge-web/.env.example
+    content: |
+      OPENROUTER_API_KEY=your-openrouter-api-key
+      SANDBOX_SECRET=generate-a-random-secret
+
+- name: Check if .env exists
+  stat:
+    path: ~/ask-forge-web/.env
+  register: env_file
+
+- name: Create .env from example if missing
+  copy:
+    src: ~/ask-forge-web/.env.example
+    dest: ~/ask-forge-web/.env
+    remote_src: true
+  when: not env_file.stat.exists
+
+- name: Display warning if .env was created
+  debug:
+    msg: |
+      WARNING: .env file was created from example.
+      Please edit ~/ask-forge-web/.env and set your API keys before starting the app.
+  when: not env_file.stat.exists

--- a/ask-forge-infra/roles/gateway/handlers/main.yml
+++ b/ask-forge-infra/roles/gateway/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart gateway
+  community.docker.docker_compose_v2:
+    project_src: ~/gateway
+    state: restarted

--- a/ask-forge-infra/roles/gateway/tasks/main.yml
+++ b/ask-forge-infra/roles/gateway/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Create gateway directory
+  file:
+    path: ~/gateway
+    state: directory
+    mode: "0755"
+
+- name: Copy gateway docker-compose.yml
+  copy:
+    dest: ~/gateway/docker-compose.yml
+    content: |
+      services:
+        caddy:
+          image: caddy:2-alpine
+          container_name: gateway
+          ports:
+            - "80:80"
+            - "443:443"
+          volumes:
+            - ./Caddyfile:/etc/caddy/Caddyfile:ro
+            - caddy_data:/data
+          networks:
+            - web
+          restart: unless-stopped
+
+      networks:
+        web:
+          name: web
+
+      volumes:
+        caddy_data:
+  notify: Restart gateway
+
+- name: Copy Caddyfile
+  copy:
+    dest: ~/gateway/Caddyfile
+    content: |
+      ask.nilenso.ai {
+          reverse_proxy ask-forge-web:3000
+      }
+
+      ask-forge-visualizer.nilenso.ai {
+          reverse_proxy ask-forge-web:3001
+      }
+  notify: Restart gateway
+
+- name: Start gateway
+  community.docker.docker_compose_v2:
+    project_src: ~/gateway
+    state: present

--- a/ask-forge-infra/roles/gvisor/handlers/main.yml
+++ b/ask-forge-infra/roles/gvisor/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Reload Docker
+  systemd:
+    name: docker
+    state: reloaded

--- a/ask-forge-infra/roles/gvisor/tasks/main.yml
+++ b/ask-forge-infra/roles/gvisor/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- name: Check if runsc is installed
+  command: which runsc
+  register: runsc_check
+  ignore_errors: true
+  changed_when: false
+
+- name: Install prerequisites
+  apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+    update_cache: true
+  when: runsc_check.rc != 0
+
+- name: Add gVisor GPG key
+  shell: |
+    curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
+  args:
+    creates: /usr/share/keyrings/gvisor-archive-keyring.gpg
+  when: runsc_check.rc != 0
+
+- name: Add gVisor apt repository
+  apt_repository:
+    repo: "deb [arch={{ ansible_architecture | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }} signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main"
+    state: present
+    filename: gvisor
+  when: runsc_check.rc != 0
+
+- name: Install runsc
+  apt:
+    name: runsc
+    state: present
+    update_cache: true
+  when: runsc_check.rc != 0
+
+- name: Register runsc as Docker runtime
+  command: runsc install
+  when: runsc_check.rc != 0
+  notify: Reload Docker
+
+- name: Verify runsc is registered with Docker
+  shell: docker info 2>/dev/null | grep -q runsc
+  changed_when: false


### PR DESCRIPTION
Replaces the shell-based setup and direct SSH deployment with Ansible playbooks.

## Changes

- **`ask-forge-infra/`** - New directory with Ansible structure:
  - `playbooks/setup.yml` - Initial server setup (gVisor, Caddy, app directories)
  - `playbooks/deploy.yml` - CI deployment playbook
  - Roles for gvisor, gateway, and app

- **Updated GitHub Actions workflow** to use Ansible instead of direct SSH commands

## Usage

```bash
# Initial server setup (run once)
cd ask-forge-infra
ansible-galaxy collection install -r requirements.yml
ansible-playbook playbooks/setup.yml

# Deployment (run by CI)
ansible-playbook playbooks/deploy.yml
```