### PR TITLE
Fix Ansible deploy: use shell commands

### DIFF
--- a/.github/workflows/ask-forge-web-docker.yml
+++ b/.github/workflows/ask-forge-web-docker.yml
@@ -68,10 +68,6 @@ jobs:
         run: |
           pip install ansible
 
-      - name: Install Ansible collections
-        run: |
-          ansible-galaxy collection install -r requirements.yml
-
       - name: Setup SSH key
         run: |
           mkdir -p ~/.ssh

--- a/ask-forge-infra/playbooks/deploy.yml
+++ b/ask-forge-infra/playbooks/deploy.yml
@@ -14,29 +14,24 @@
 
   tasks:
     - name: Pull latest images
-      community.docker.docker_compose_v2:
-        project_src: ~/ask-forge-web
-        pull: always
-        state: present
-      register: compose_pull
+      shell: |
+        cd ~/ask-forge-web
+        docker compose pull
+      register: pull_result
 
     - name: Stop and remove old containers
-      community.docker.docker_compose_v2:
-        project_src: ~/ask-forge-web
-        state: absent
-        remove_orphans: true
-      when: compose_pull.changed
+      shell: |
+        cd ~/ask-forge-web
+        docker compose down --remove-orphans || true
+      when: pull_result.changed
 
     - name: Start application
-      community.docker.docker_compose_v2:
-        project_src: ~/ask-forge-web
-        state: present
+      shell: |
+        cd ~/ask-forge-web
+        docker compose up -d
 
     - name: Prune old Docker images
-      community.docker.docker_prune:
-        images: true
-        images_filters:
-          dangling: false
+      shell: docker image prune -f
 
     - name: Wait for app to be healthy
       uri:
@@ -47,7 +42,8 @@
       delay: 2
       until: health_check.status == 200
       ignore_errors: true
+      delegate_to: localhost
 
     - name: Display deployment result
       debug:
-        msg: "{{ 'Deployment successful! App is healthy.' if health_check.status == 200 else 'Warning: App may not be healthy yet.' }}"
+        msg: "Deployment complete"

--- a/ask-forge-infra/roles/app/handlers/main.yml
+++ b/ask-forge-infra/roles/app/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Restart app
-  community.docker.docker_compose_v2:
-    project_src: ~/ask-forge-web
-    state: restarted
+  shell: |
+    cd ~/ask-forge-web
+    docker compose restart

--- a/ask-forge-infra/roles/gateway/handlers/main.yml
+++ b/ask-forge-infra/roles/gateway/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Restart gateway
-  community.docker.docker_compose_v2:
-    project_src: ~/gateway
-    state: restarted
+  shell: |
+    cd ~/gateway
+    docker compose restart

--- a/ask-forge-infra/roles/gateway/tasks/main.yml
+++ b/ask-forge-infra/roles/gateway/tasks/main.yml
@@ -29,7 +29,7 @@
 
       volumes:
         caddy_data:
-  notify: Restart gateway
+  register: gateway_compose
 
 - name: Copy Caddyfile
   copy:
@@ -42,9 +42,15 @@
       ask-forge-visualizer.nilenso.ai {
           reverse_proxy ask-forge-web:3001
       }
-  notify: Restart gateway
+  register: gateway_caddyfile
 
 - name: Start gateway
-  community.docker.docker_compose_v2:
-    project_src: ~/gateway
-    state: present
+  shell: |
+    cd ~/gateway
+    docker compose up -d
+  when: gateway_compose.changed or gateway_caddyfile.changed
+
+- name: Ensure gateway is running
+  shell: |
+    cd ~/gateway
+    docker compose up -d


### PR DESCRIPTION
The community.docker module requires additional Python packages on the runner. Using shell commands is simpler and matches the original approach.