### PR TITLE
Auto-send when clicking example prompts

### DIFF
--- a/ask-forge-web/src/client/App.tsx
+++ b/ask-forge-web/src/client/App.tsx
@@ -220,10 +220,10 @@ export function App() {
 		restoringFromUrlRef.current = false;
 	}, [connection.sessionId]);
 
-	const handleSend = useCallback(() => {
-		if (!inputValue.trim() || !connection.sessionId || isAsking) return;
+	const handleSend = useCallback((questionOverride?: string) => {
+		const question = (questionOverride || inputValue).trim();
+		if (!question || !connection.sessionId || isAsking) return;
 
-		const question = inputValue.trim();
 		const requestId = generateRequestId();
 
 		setInputValue("");
@@ -599,6 +599,7 @@ export function App() {
 				setInputValue={setInputValue}
 				isAsking={isAsking}
 				handleKeyDown={handleKeyDown}
+				handleSend={handleSend}
 				handleDisconnect={handleDisconnect}
 				askTextareaRef={askTextareaRef}
 				sidebarProps={sidebarProps}

--- a/ask-forge-web/src/client/components/AskPhase.tsx
+++ b/ask-forge-web/src/client/components/AskPhase.tsx
@@ -7,6 +7,7 @@ interface AskPhaseProps {
 	setInputValue: (value: string) => void;
 	isAsking: boolean;
 	handleKeyDown: (e: React.KeyboardEvent) => void;
+	handleSend: (question?: string) => void;
 	handleDisconnect: () => void;
 	askTextareaRef: React.RefObject<HTMLTextAreaElement | null>;
 	sidebarProps: React.ComponentProps<typeof Sidebar>;
@@ -24,13 +25,13 @@ export function AskPhase({
 	setInputValue,
 	isAsking,
 	handleKeyDown,
+	handleSend,
 	handleDisconnect,
 	askTextareaRef,
 	sidebarProps,
 }: AskPhaseProps) {
 	const handleExampleClick = (question: string) => {
-		setInputValue(question);
-		askTextareaRef.current?.focus();
+		handleSend(question);
 	};
 
 	return (


### PR DESCRIPTION
Clicking an example prompt now automatically sends it instead of just filling the textarea.