### PR TITLE
Fix bookmarklet title

### DIFF
--- a/ask-forge-web/public/index.html
+++ b/ask-forge-web/public/index.html
@@ -1479,6 +1479,14 @@
 			flex-shrink: 0;
 		}
 
+		.bookmarklet-hint {
+			display: block;
+			text-align: center;
+			font-size: 10px;
+			color: var(--text-muted);
+			margin-top: 4px;
+		}
+
 		.sidebar-footer {
 			flex-shrink: 0;
 			padding: 8px 12px;

--- a/ask-forge-web/src/client/components/Sidebar.tsx
+++ b/ask-forge-web/src/client/components/Sidebar.tsx
@@ -196,15 +196,15 @@ export function Sidebar({
 					<a
 						ref={bookmarkletRef}
 						href="#"
-						title="AskForge!"
 						className="bookmarklet-link"
 						onClick={(e) => e.preventDefault()}
 					>
 						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
 							<path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
 						</svg>
-						Drag to bookmarks bar
+						AskForge!
 					</a>
+					<span className="bookmarklet-hint">↑ Drag to bookmarks bar</span>
 				</div>
 			)}
 			<div className="sidebar-footer" ref={profileRef}>


### PR DESCRIPTION
The bookmark title comes from the link text, not the title attribute. Changed the link text to 'AskForge!' with a hint below.