### PR TITLE
Fix auto-scroll fighting with user scrolling

### DIFF
--- a/ask-forge-web/src/client/App.tsx
+++ b/ask-forge-web/src/client/App.tsx
@@ -57,6 +57,8 @@ export function App() {
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const shouldAutoScrollRef = useRef(true);
 	const [isAutoScrolling, setIsAutoScrolling] = useState(true);
+	const userScrolledRef = useRef(false);
+	const userScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const isProgrammaticScrollRef = useRef(false);
 	const phaseRef = useRef(phase);
 	phaseRef.current = phase;
@@ -348,7 +350,18 @@ export function App() {
 		if (!container) return;
 		const { scrollTop, scrollHeight, clientHeight } = container;
 		const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
-		const shouldAutoScroll = distanceFromBottom < 100;
+		const shouldAutoScroll = distanceFromBottom < 50;
+
+		// Mark that user scrolled manually
+		userScrolledRef.current = true;
+		if (userScrollTimeoutRef.current) {
+			clearTimeout(userScrollTimeoutRef.current);
+		}
+		// Clear the user-scrolled flag after a brief delay
+		userScrollTimeoutRef.current = setTimeout(() => {
+			userScrolledRef.current = false;
+		}, 150);
+
 		shouldAutoScrollRef.current = shouldAutoScroll;
 		setIsAutoScrolling(shouldAutoScroll);
 	}, []);
@@ -526,13 +539,20 @@ export function App() {
 
 	// Auto-scroll to bottom when messages change
 	useEffect(() => {
-		if (shouldAutoScrollRef.current && messagesEndRef.current) {
-			isProgrammaticScrollRef.current = true;
-			messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
-			setTimeout(() => {
-				isProgrammaticScrollRef.current = false;
-			}, 100);
-		}
+		// Don't auto-scroll if user is actively scrolling or has scrolled away from bottom
+		if (userScrolledRef.current || !shouldAutoScrollRef.current) return;
+
+		const container = messagesContainerRef.current;
+		if (!container) return;
+
+		// Use instant scroll (not smooth) to avoid fighting with user input
+		isProgrammaticScrollRef.current = true;
+		container.scrollTop = container.scrollHeight;
+
+		// Reset the programmatic flag after a frame
+		requestAnimationFrame(() => {
+			isProgrammaticScrollRef.current = false;
+		});
 	}, [messages]);
 
 	// --- Sidebar props ---


### PR DESCRIPTION
The smooth scroll animation was conflicting with user scroll input during streaming. 

Changes:
- Use instant scrolling instead of smooth
- Detect active user scrolling and temporarily disable auto-scroll
- Smaller threshold (50px) for determining 'at bottom'