### PR TITLE
Add three glow states based on streaming activity

### DIFF
--- a/ask-forge-web/public/index.html
+++ b/ask-forge-web/public/index.html
@@ -454,28 +454,49 @@
 			bottom: 0;
 			left: 0;
 			right: 0;
-			height: 24px;
 			pointer-events: none;
+		}
+
+		/* Subtle: waiting/thinking, barely visible */
+		.streaming-glow-subtle {
+			height: 12px;
+			background: linear-gradient(
+				to top,
+				rgba(236, 72, 153, 0.05) 0%,
+				transparent 100%
+			);
+			animation: glow-pulse-subtle 3s ease-in-out infinite;
+		}
+
+		/* Active: streaming but user scrolled up */
+		.streaming-glow-active {
+			height: 20px;
 			background: linear-gradient(
 				to top,
 				rgba(236, 72, 153, 0.1) 0%,
 				transparent 100%
 			);
-			animation: glow-pulse 2s ease-in-out infinite;
+			animation: glow-pulse-active 2s ease-in-out infinite;
 		}
 
+		/* Emphatic: streaming + auto-scrolling */
 		.streaming-glow-emphatic {
-			height: 32px;
+			height: 28px;
 			background: linear-gradient(
 				to top,
-				rgba(236, 72, 153, 0.2) 0%,
-				rgba(168, 85, 247, 0.08) 50%,
+				rgba(236, 72, 153, 0.18) 0%,
+				rgba(168, 85, 247, 0.06) 60%,
 				transparent 100%
 			);
 			animation: glow-pulse-emphatic 1.5s ease-in-out infinite;
 		}
 
-		@keyframes glow-pulse {
+		@keyframes glow-pulse-subtle {
+			0%, 100% { opacity: 0.4; }
+			50% { opacity: 0.7; }
+		}
+
+		@keyframes glow-pulse-active {
 			0%, 100% { opacity: 0.5; }
 			50% { opacity: 1; }
 		}

--- a/ask-forge-web/src/client/components/MessageList.tsx
+++ b/ask-forge-web/src/client/components/MessageList.tsx
@@ -34,7 +34,18 @@ export function MessageList({
 	handleMessagesScroll,
 }: MessageListProps) {
 	const isStreaming = messages.some((m) => m.isStreaming);
-	const showStreamingGlow = isAsking || isStreaming;
+
+	// Determine glow state:
+	// - "emphatic" = actively streaming + auto-scrolling (most visible)
+	// - "active" = actively streaming but user scrolled up (visible)
+	// - "subtle" = waiting/thinking but not streaming yet (barely visible)
+	// - null = idle, no glow
+	let glowState: "emphatic" | "active" | "subtle" | null = null;
+	if (isStreaming) {
+		glowState = isAutoScrolling ? "emphatic" : "active";
+	} else if (isAsking) {
+		glowState = "subtle";
+	}
 
 	return (
 		<div className="messages-wrapper">
@@ -248,8 +259,8 @@ export function MessageList({
 			)}
 				<div ref={messagesEndRef} />
 			</div>
-			{showStreamingGlow && (
-				<div className={`streaming-glow ${isAutoScrolling ? "streaming-glow-emphatic" : ""}`} />
+			{glowState && (
+				<div className={`streaming-glow streaming-glow-${glowState}`} />
 			)}
 		</div>
 	);


### PR DESCRIPTION
Now the glow only shows during active streaming/thinking:
- **subtle**: waiting/thinking, barely visible
- **active**: streaming but scrolled up
- **emphatic**: streaming + auto-scrolling
- **none**: idle, no glow