### PR TITLE
Fix streaming glow bug and simplify code

### DIFF
--- a/ask-forge-web/public/index.html
+++ b/ask-forge-web/public/index.html
@@ -454,54 +454,18 @@
 			bottom: 0;
 			left: 0;
 			right: 0;
+			height: 16px;
 			pointer-events: none;
+			background: linear-gradient(to top, rgba(236, 72, 153, 0.08) 0%, transparent 100%);
+			animation: glow-pulse 2s ease-in-out infinite;
 		}
 
-		/* Subtle: waiting/thinking, barely visible */
-		.streaming-glow-subtle {
-			height: 12px;
-			background: linear-gradient(
-				to top,
-				rgba(236, 72, 153, 0.05) 0%,
-				transparent 100%
-			);
-			animation: glow-pulse-subtle 3s ease-in-out infinite;
-		}
-
-		/* Active: streaming but user scrolled up */
-		.streaming-glow-active {
-			height: 20px;
-			background: linear-gradient(
-				to top,
-				rgba(236, 72, 153, 0.1) 0%,
-				transparent 100%
-			);
-			animation: glow-pulse-active 2s ease-in-out infinite;
-		}
-
-		/* Emphatic: streaming + auto-scrolling */
 		.streaming-glow-emphatic {
-			height: 28px;
-			background: linear-gradient(
-				to top,
-				rgba(236, 72, 153, 0.18) 0%,
-				rgba(168, 85, 247, 0.06) 60%,
-				transparent 100%
-			);
-			animation: glow-pulse-emphatic 1.5s ease-in-out infinite;
+			height: 24px;
+			background: linear-gradient(to top, rgba(236, 72, 153, 0.15) 0%, transparent 100%);
 		}
 
-		@keyframes glow-pulse-subtle {
-			0%, 100% { opacity: 0.4; }
-			50% { opacity: 0.7; }
-		}
-
-		@keyframes glow-pulse-active {
-			0%, 100% { opacity: 0.5; }
-			50% { opacity: 1; }
-		}
-
-		@keyframes glow-pulse-emphatic {
+		@keyframes glow-pulse {
 			0%, 100% { opacity: 0.6; }
 			50% { opacity: 1; }
 		}

--- a/ask-forge-web/src/client/components/MessageList.tsx
+++ b/ask-forge-web/src/client/components/MessageList.tsx
@@ -34,18 +34,7 @@ export function MessageList({
 	handleMessagesScroll,
 }: MessageListProps) {
 	const isStreaming = messages.some((m) => m.isStreaming);
-
-	// Determine glow state:
-	// - "emphatic" = actively streaming + auto-scrolling (most visible)
-	// - "active" = actively streaming but user scrolled up (visible)
-	// - "subtle" = waiting/thinking but not streaming yet (barely visible)
-	// - null = idle, no glow
-	let glowState: "emphatic" | "active" | "subtle" | null = null;
-	if (isStreaming) {
-		glowState = isAutoScrolling ? "emphatic" : "active";
-	} else if (isAsking) {
-		glowState = "subtle";
-	}
+	const showGlow = isAsking || isStreaming;
 
 	return (
 		<div className="messages-wrapper">
@@ -259,8 +248,8 @@ export function MessageList({
 			)}
 				<div ref={messagesEndRef} />
 			</div>
-			{glowState && (
-				<div className={`streaming-glow streaming-glow-${glowState}`} />
+			{showGlow && (
+				<div className={`streaming-glow${isAutoScrolling ? " streaming-glow-emphatic" : ""}`} />
 			)}
 		</div>
 	);

--- a/ask-forge-web/src/client/hooks/useWebSocket.ts
+++ b/ask-forge-web/src/client/hooks/useWebSocket.ts
@@ -211,7 +211,7 @@ export function useWebSocket({
 							setMessages((prev) =>
 								prev.map((msg) =>
 									msg.id === streamingMessageIdRef.current
-										? { ...msg, contentBlocks: blocksToUse, isStreaming: !isResumingRef.current }
+										? { ...msg, contentBlocks: blocksToUse, isStreaming: false }
 										: msg,
 								),
 							);


### PR DESCRIPTION
**Bug fix**: `isStreaming` was set to `!isResumingRef.current` which meant it stayed `true` after streaming completed.

**Simplified**: Reduced glow states from 3 to 2 (normal + emphatic).