### PR TITLE
docs: update visualizer section to reflect SQLite-based sessions

### DIFF
--- a/ask-forge-web/README.md
+++ b/ask-forge-web/README.md
@@ -71,20 +71,18 @@ The app will only start after migrations complete successfully.
 
 ## Session Visualizer
 
-A separate tool for visualizing `.jsonl` session files (e.g., from pi coding agent sessions).
+A tool for visualizing ask-forge sessions stored in the SQLite database.
 
 ```bash
-# Run visualizer (default: looks for .jsonl files in current directory)
 bun run dev:visualizer
-
-# Specify a directory containing session files
-SESSION_DIR=/path/to/sessions bun run dev:visualizer
 ```
 
 The visualizer runs on port 3001 and provides:
-- Dropdown to select between multiple `.jsonl` files
-- Session metadata display (ID, timestamp, working directory)
-- Formatted conversation view with user messages, assistant responses, thinking blocks, and tool calls/results
+- Sidebar with searchable session list and status filtering (active/inactive/error)
+- Session metadata display (repo, commit, timestamp, duration)
+- Formatted conversation view with user messages, assistant responses, and tool calls/results
+- Annotations for rating response quality (relevance, evidence, clarity)
+- Export to JSONL format
 
 ## Scripts
 


### PR DESCRIPTION
The visualizer now reads sessions from the SQLite database directly, not from arbitrary .jsonl file directories.

**Changes:**
- Remove SESSION_DIR environment variable reference
- Update feature list to match current functionality (sidebar, filtering, annotations, export)
- Clarify that sessions come from the ask-forge-web database