### PR TITLE
Add stop button to interrupt an ongoing request and edit the pr…

### DIFF
--- a/ask-forge-web/public/index.html
+++ b/ask-forge-web/public/index.html
@@ -186,6 +186,7 @@
 			display: flex;
 			align-items: center;
 			justify-content: center;
+			gap: 6px;
 			min-width: 100px;
 		}
 
@@ -203,6 +204,32 @@
 		.send-button:disabled {
 			opacity: 0.5;
 			cursor: not-allowed;
+		}
+
+		.stop-button {
+			padding: 12px 24px;
+			background: var(--text-secondary);
+			color: #ffffff;
+			border: none;
+			border-radius: 8px;
+			font-size: 15px;
+			font-weight: 600;
+			font-family: inherit;
+			cursor: pointer;
+			transition: background 0.2s, transform 0.1s;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			gap: 6px;
+			min-width: 100px;
+		}
+
+		.stop-button:hover {
+			background: var(--text-primary);
+		}
+
+		.stop-button:active {
+			transform: scale(0.98);
 		}
 
 		/* Disconnect Link */
@@ -1809,6 +1836,71 @@
 		}
 
 		.example-question:disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
+
+		/* Message Edit Styles */
+		.message-edit-container {
+			display: flex;
+			flex-direction: column;
+			gap: 12px;
+		}
+
+		.message-edit-textarea {
+			width: 100%;
+			padding: 12px 16px;
+			background: var(--bg-primary);
+			border: 2px solid var(--accent-pink);
+			border-radius: 8px;
+			color: var(--text-primary);
+			font-size: 15px;
+			font-family: inherit;
+			line-height: 1.5;
+			resize: vertical;
+			min-height: 100px;
+			outline: none;
+		}
+
+		.message-edit-actions {
+			display: flex;
+			gap: 8px;
+			justify-content: flex-end;
+		}
+
+		.message-edit-cancel,
+		.message-edit-save {
+			padding: 8px 16px;
+			border-radius: 6px;
+			font-size: 14px;
+			font-weight: 500;
+			font-family: inherit;
+			cursor: pointer;
+			transition: all 0.2s;
+		}
+
+		.message-edit-cancel {
+			background: none;
+			border: 1px solid var(--border-subtle);
+			color: var(--text-secondary);
+		}
+
+		.message-edit-cancel:hover {
+			background: var(--bg-secondary);
+			border-color: var(--text-secondary);
+		}
+
+		.message-edit-save {
+			background: var(--accent-pink);
+			border: none;
+			color: #ffffff;
+		}
+
+		.message-edit-save:hover:not(:disabled) {
+			background: var(--accent-pink-hover);
+		}
+
+		.message-edit-save:disabled {
 			opacity: 0.5;
 			cursor: not-allowed;
 		}

--- a/ask-forge-web/src/client/App.tsx
+++ b/ask-forge-web/src/client/App.tsx
@@ -49,6 +49,8 @@ export function App() {
 	const [votes, setVotes] = useState<Record<string, "like" | "dislike">>({});
 	const [copiedId, setCopiedId] = useState<string | null>(null);
 	const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+	const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+	const [editValue, setEditValue] = useState("");
 
 	const urlInputRef = useRef<HTMLInputElement>(null);
 	const askTextareaRef = useRef<HTMLTextAreaElement>(null);
@@ -227,7 +229,7 @@ export function App() {
 	const handleSend = useCallback(
 		(questionOverride?: string) => {
 			const question = (questionOverride || inputValue).trim();
-			if (!question || !connection.sessionId || isAsking) return;
+			if (!question || !connection.sessionId || isAsking || currentRequestIdRef.current !== null) return;
 
 			const requestId = generateRequestId();
 
@@ -274,7 +276,7 @@ export function App() {
 
 	const handleResend = useCallback(
 		(question: string) => {
-			if (!connection.sessionId || isAsking) return;
+			if (!connection.sessionId || isAsking || currentRequestIdRef.current !== null) return;
 
 			const requestId = generateRequestId();
 
@@ -310,6 +312,58 @@ export function App() {
 			requestToSessionRef,
 			sessionRequestRef,
 		],
+	);
+
+	const handleCancel = useCallback(() => {
+		const requestId = currentRequestIdRef.current;
+		if (requestId && wsRef.current?.readyState === WebSocket.OPEN) {
+			wsRef.current.send(JSON.stringify({ type: "cancel", requestId }));
+		}
+
+		// Immediately clean up ALL streaming messages without waiting for server response
+		setMessages((prev) => prev.map((msg) => (msg.isStreaming ? { ...msg, isStreaming: false } : msg)));
+
+		streaming.streamingMessageIdRef.current = null;
+		streaming.streamingThinkingRef.current = "";
+		streaming.streamingBlocksRef.current = [];
+		streaming.textBufferRef.current = "";
+		streaming.stopReleaseLoop();
+
+		currentRequestIdRef.current = null;
+		pendingMessageRef.current = null;
+		setIsAsking(false);
+		setProgress({ type: "idle" });
+	}, [wsRef, currentRequestIdRef, streaming, pendingMessageRef, setMessages, setIsAsking, setProgress]);
+
+	const handleStartEdit = useCallback((messageId: string, currentContent: string) => {
+		setEditingMessageId(messageId);
+		setEditValue(currentContent);
+	}, []);
+
+	const handleCancelEdit = useCallback(() => {
+		setEditingMessageId(null);
+		setEditValue("");
+	}, []);
+
+	const handleSaveEdit = useCallback(
+		(messageId: string) => {
+			if (!editValue.trim()) return;
+
+			// Find the message index
+			const msgIndex = messages.findIndex((m) => m.id === messageId);
+			if (msgIndex === -1) return;
+
+			// Remove all messages after this one (including the message itself)
+			setMessages((prev) => prev.slice(0, msgIndex));
+
+			// Clear editing state
+			setEditingMessageId(null);
+			setEditValue("");
+
+			// Send the edited message
+			handleSend(editValue.trim());
+		},
+		[messages, editValue, handleSend],
 	);
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -678,6 +732,13 @@ export function App() {
 			handleVote={handleVote}
 			handleSend={handleSend}
 			handleResend={handleResend}
+			handleCancel={handleCancel}
+			editingMessageId={editingMessageId}
+			editValue={editValue}
+			setEditValue={setEditValue}
+			handleStartEdit={handleStartEdit}
+			handleSaveEdit={handleSaveEdit}
+			handleCancelEdit={handleCancelEdit}
 			handleKeyDown={handleKeyDown}
 			handleShareSession={handleShareSession}
 			messagesContainerRef={messagesContainerRef}

--- a/ask-forge-web/src/client/components/ChatPhase.tsx
+++ b/ask-forge-web/src/client/components/ChatPhase.tsx
@@ -19,6 +19,13 @@ interface ChatPhaseProps {
 	handleVote: (msgId: string, vote: "like" | "dislike") => void;
 	handleSend: () => void;
 	handleResend: (question: string) => void;
+	handleCancel: () => void;
+	editingMessageId: string | null;
+	editValue: string;
+	setEditValue: (value: string) => void;
+	handleStartEdit: (messageId: string, currentContent: string) => void;
+	handleSaveEdit: (messageId: string) => void;
+	handleCancelEdit: () => void;
 	handleKeyDown: (e: React.KeyboardEvent) => void;
 	handleShareSession: (sessionId: string) => void;
 	messagesContainerRef: React.RefObject<HTMLDivElement | null>;
@@ -44,6 +51,13 @@ export function ChatPhase({
 	handleVote,
 	handleSend,
 	handleResend,
+	handleCancel,
+	editingMessageId,
+	editValue,
+	setEditValue,
+	handleStartEdit,
+	handleSaveEdit,
+	handleCancelEdit,
 	handleKeyDown,
 	handleShareSession,
 	messagesContainerRef,
@@ -107,6 +121,12 @@ export function ChatPhase({
 						markedWithLinks={markedWithLinks}
 						handleCopyMessage={handleCopyMessage}
 						handleResend={handleResend}
+						editingMessageId={editingMessageId}
+						editValue={editValue}
+						setEditValue={setEditValue}
+						handleStartEdit={handleStartEdit}
+						handleSaveEdit={handleSaveEdit}
+						handleCancelEdit={handleCancelEdit}
 						handleVote={handleVote}
 						messagesContainerRef={messagesContainerRef}
 						messagesEndRef={messagesEndRef}
@@ -128,11 +148,27 @@ export function ChatPhase({
 						/>
 						<button
 							type="button"
-							className="send-button"
-							onClick={handleSend}
-							disabled={isAsking || !inputValue.trim()}
+							className={isAsking ? "stop-button" : "send-button"}
+							onClick={isAsking ? handleCancel : handleSend}
+							disabled={!isAsking && !inputValue.trim()}
 						>
-							{isAsking ? <span className="spinner small" /> : "Send"}
+							{isAsking ? (
+								<>
+									<svg
+										viewBox="0 0 24 24"
+										width="16"
+										height="16"
+										fill="currentColor"
+										stroke="none"
+										aria-hidden="true"
+									>
+										<rect x="6" y="6" width="12" height="12" rx="1" />
+									</svg>
+									Stop
+								</>
+							) : (
+								"Send"
+							)}
 						</button>
 					</div>
 				</footer>

--- a/ask-forge-web/src/client/components/MessageList.tsx
+++ b/ask-forge-web/src/client/components/MessageList.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { Marked } from "marked";
 import type { ContentBlock, Message, ProgressState } from "../types.ts";
 import { formatToolCall } from "../utils.ts";
@@ -12,6 +13,12 @@ interface MessageListProps {
 	markedWithLinks: Marked;
 	handleCopyMessage: (msgId: string, blocks: ContentBlock[]) => void;
 	handleResend: (question: string) => void;
+	editingMessageId: string | null;
+	editValue: string;
+	setEditValue: (value: string) => void;
+	handleStartEdit: (messageId: string, currentContent: string) => void;
+	handleSaveEdit: (messageId: string) => void;
+	handleCancelEdit: () => void;
 	handleVote: (msgId: string, vote: "like" | "dislike") => void;
 	messagesContainerRef: React.RefObject<HTMLDivElement | null>;
 	messagesEndRef: React.RefObject<HTMLDivElement | null>;
@@ -28,30 +35,181 @@ export function MessageList({
 	markedWithLinks,
 	handleCopyMessage,
 	handleResend,
+	editingMessageId,
+	editValue,
+	setEditValue,
+	handleStartEdit,
+	handleSaveEdit,
+	handleCancelEdit,
 	handleVote,
 	messagesContainerRef,
 	messagesEndRef,
 	handleMessagesScroll,
 }: MessageListProps) {
 	const isStreaming = messages.some((m) => m.isStreaming);
-	const showGlow = isAsking || isStreaming;
+	const showStreamingGlow = isAsking || isStreaming;
+	const editTextareaRef = useRef<HTMLTextAreaElement>(null);
+
+	// Set cursor to end when entering edit mode
+	useEffect(() => {
+		if (editingMessageId && editTextareaRef.current) {
+			const textarea = editTextareaRef.current;
+			const length = textarea.value.length;
+			textarea.setSelectionRange(length, length);
+		}
+	}, [editingMessageId]);
 
 	return (
 		<div className="messages-wrapper">
 			<div className="messages" ref={messagesContainerRef} onScroll={handleMessagesScroll}>
-				{messages.map((msg) => (
-					<div key={msg.id} className={`message message-${msg.role}${msg.isStreaming ? " streaming" : ""}`}>
-						<div className="message-role">
-							{msg.role === "user" ? "You" : "Assistant"}
-							{msg.isStreaming && <span className="streaming-indicator" />}
-						</div>
-						{msg.thinking && (
-							<details className="thinking-block" open={msg.isStreaming}>
-								<summary>Thinking...</summary>
-								<div className="thinking-content">{msg.thinking}</div>
-							</details>
-						)}
-						{msg.contentBlocks.map((block, idx) =>
+			{messages.map((msg) => (
+				<div key={msg.id} className={`message message-${msg.role}${msg.isStreaming ? " streaming" : ""}`}>
+					<div className="message-role">
+						{msg.role === "user" ? "You" : "Assistant"}
+						{msg.isStreaming && <span className="streaming-indicator" />}
+					</div>
+					{msg.thinking && (
+						<details className="thinking-block" open={msg.isStreaming}>
+							<summary>Thinking...</summary>
+							<div className="thinking-content">{msg.thinking}</div>
+						</details>
+					)}
+					{msg.role === "user" ? (
+						editingMessageId === msg.id ? (
+							<div className="message-edit-container">
+								<textarea
+									ref={editTextareaRef}
+									value={editValue}
+									onChange={(e) => setEditValue(e.target.value)}
+									className="message-edit-textarea"
+									rows={4}
+									autoFocus
+									onKeyDown={(e) => {
+										if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+											handleSaveEdit(msg.id);
+										} else if (e.key === "Escape") {
+											handleCancelEdit();
+										}
+									}}
+								/>
+								<div className="message-edit-actions">
+									<button
+										type="button"
+										className="message-edit-cancel"
+										onClick={handleCancelEdit}
+									>
+										Cancel
+									</button>
+									<button
+										type="button"
+										className="message-edit-save"
+										onClick={() => handleSaveEdit(msg.id)}
+										disabled={!editValue.trim()}
+									>
+										Save & Submit
+									</button>
+								</div>
+							</div>
+						) : (
+							<>
+								{msg.contentBlocks.map((block, idx) =>
+									block.type === "text" ? (
+										<div
+											key={`${msg.id}-text-${idx}`}
+											className="markdown-content"
+											dangerouslySetInnerHTML={{ __html: markedWithLinks.parse(block.content) as string }}
+										/>
+									) : null
+								)}
+								{!isAsking && (
+									<div className="message-actions">
+										<button
+											type="button"
+											title={copiedId === msg.id ? "Copied!" : "Copy"}
+											onClick={() => handleCopyMessage(msg.id, msg.contentBlocks)}
+										>
+											{copiedId === msg.id ? (
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													fill="none"
+													viewBox="0 0 24 24"
+													strokeWidth={1.5}
+													stroke="currentColor"
+												>
+													<path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+												</svg>
+											) : (
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													fill="none"
+													viewBox="0 0 24 24"
+													strokeWidth={1.5}
+													stroke="currentColor"
+												>
+													<path
+														strokeLinecap="round"
+														strokeLinejoin="round"
+														d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
+													/>
+												</svg>
+											)}
+										</button>
+										<button
+											type="button"
+											title="Edit"
+											onClick={() => {
+												const text = msg.contentBlocks
+													.filter((b): b is ContentBlock & { type: "text" } => b.type === "text")
+													.map((b) => b.content)
+													.join("\n\n");
+												handleStartEdit(msg.id, text);
+											}}
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												fill="none"
+												viewBox="0 0 24 24"
+												strokeWidth={1.5}
+												stroke="currentColor"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
+												/>
+											</svg>
+										</button>
+										<button
+											type="button"
+											title="Resend"
+											onClick={() => {
+												const text = msg.contentBlocks
+													.filter((b): b is ContentBlock & { type: "text" } => b.type === "text")
+													.map((b) => b.content)
+													.join("\n\n");
+												handleResend(text);
+											}}
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												fill="none"
+												viewBox="0 0 24 24"
+												strokeWidth={1.5}
+												stroke="currentColor"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.992 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182"
+												/>
+											</svg>
+										</button>
+									</div>
+								)}
+							</>
+						)
+					) : (
+						msg.contentBlocks.map((block, idx) =>
 							block.type === "text" ? (
 								<div
 									key={`${msg.id}-text-${idx}`}
@@ -71,51 +229,26 @@ export function MessageList({
 									{Object.keys(block.arguments).length > 0 && <pre>{JSON.stringify(block.arguments, null, 2)}</pre>}
 								</details>
 							),
-						)}
-						{msg.role === "user" && !isAsking && (
-							<div className="message-actions">
-								<button
-									type="button"
-									title={copiedId === msg.id ? "Copied!" : "Copy"}
-									onClick={() => handleCopyMessage(msg.id, msg.contentBlocks)}
-								>
-									{copiedId === msg.id ? (
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											fill="none"
-											viewBox="0 0 24 24"
-											strokeWidth={1.5}
-											stroke="currentColor"
-										>
-											<path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-										</svg>
-									) : (
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											fill="none"
-											viewBox="0 0 24 24"
-											strokeWidth={1.5}
-											stroke="currentColor"
-										>
-											<path
-												strokeLinecap="round"
-												strokeLinejoin="round"
-												d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
-											/>
-										</svg>
-									)}
-								</button>
-								<button
-									type="button"
-									title="Resend"
-									onClick={() => {
-										const text = msg.contentBlocks
-											.filter((b): b is ContentBlock & { type: "text" } => b.type === "text")
-											.map((b) => b.content)
-											.join("\n\n");
-										handleResend(text);
-									}}
-								>
+						)
+					)}
+					{msg.role === "assistant" && !isAsking && (
+						<div className="message-actions">
+							<button
+								type="button"
+								title={copiedId === msg.id ? "Copied!" : "Copy"}
+								onClick={() => handleCopyMessage(msg.id, msg.contentBlocks)}
+							>
+								{copiedId === msg.id ? (
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										fill="none"
+										viewBox="0 0 24 24"
+										strokeWidth={1.5}
+										stroke="currentColor"
+									>
+										<path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+									</svg>
+								) : (
 									<svg
 										xmlns="http://www.w3.org/2000/svg"
 										fill="none"
@@ -126,129 +259,97 @@ export function MessageList({
 										<path
 											strokeLinecap="round"
 											strokeLinejoin="round"
-											d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.992 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182"
+											d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
 										/>
 									</svg>
-								</button>
-							</div>
-						)}
-						{msg.role === "assistant" && !isAsking && (
-							<div className="message-actions">
-								<button
-									type="button"
-									title={copiedId === msg.id ? "Copied!" : "Copy"}
-									onClick={() => handleCopyMessage(msg.id, msg.contentBlocks)}
+								)}
+							</button>
+							<button
+								type="button"
+								title="Thumbs up"
+								className={votes[msg.id] === "like" ? "active" : ""}
+								onClick={() => handleVote(msg.id, "like")}
+							>
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									fill="none"
+									viewBox="0 0 24 24"
+									strokeWidth={1.5}
+									stroke="currentColor"
 								>
-									{copiedId === msg.id ? (
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											fill="none"
-											viewBox="0 0 24 24"
-											strokeWidth={1.5}
-											stroke="currentColor"
-										>
-											<path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-										</svg>
-									) : (
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											fill="none"
-											viewBox="0 0 24 24"
-											strokeWidth={1.5}
-											stroke="currentColor"
-										>
-											<path
-												strokeLinecap="round"
-												strokeLinejoin="round"
-												d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
-											/>
-										</svg>
-									)}
-								</button>
-								<button
-									type="button"
-									title="Thumbs up"
-									className={votes[msg.id] === "like" ? "active" : ""}
-									onClick={() => handleVote(msg.id, "like")}
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										d="M6.633 10.25c.806 0 1.533-.446 2.031-1.08a9.041 9.041 0 0 1 2.861-2.4c.723-.384 1.35-.956 1.653-1.715a4.498 4.498 0 0 0 .322-1.672V2.75a.75.75 0 0 1 .75-.75 2.25 2.25 0 0 1 2.25 2.25c0 1.152-.26 2.243-.723 3.218-.266.558.107 1.282.725 1.282m0 0h3.126c1.026 0 1.945.694 2.054 1.715.045.422.068.85.068 1.285a11.95 11.95 0 0 1-2.649 7.521c-.388.482-.987.729-1.605.729H13.48c-.483 0-.964-.078-1.423-.23l-3.114-1.04a4.501 4.501 0 0 0-1.423-.23H3.75"
+									/>
+								</svg>
+							</button>
+							<button
+								type="button"
+								title="Thumbs down"
+								className={votes[msg.id] === "dislike" ? "active" : ""}
+								onClick={() => handleVote(msg.id, "dislike")}
+							>
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									fill="none"
+									viewBox="0 0 24 24"
+									strokeWidth={1.5}
+									stroke="currentColor"
 								>
-									<svg
-										xmlns="http://www.w3.org/2000/svg"
-										fill="none"
-										viewBox="0 0 24 24"
-										strokeWidth={1.5}
-										stroke="currentColor"
-									>
-										<path
-											strokeLinecap="round"
-											strokeLinejoin="round"
-											d="M6.633 10.25c.806 0 1.533-.446 2.031-1.08a9.041 9.041 0 0 1 2.861-2.4c.723-.384 1.35-.956 1.653-1.715a4.498 4.498 0 0 0 .322-1.672V2.75a.75.75 0 0 1 .75-.75 2.25 2.25 0 0 1 2.25 2.25c0 1.152-.26 2.243-.723 3.218-.266.558.107 1.282.725 1.282m0 0h3.126c1.026 0 1.945.694 2.054 1.715.045.422.068.85.068 1.285a11.95 11.95 0 0 1-2.649 7.521c-.388.482-.987.729-1.605.729H13.48c-.483 0-.964-.078-1.423-.23l-3.114-1.04a4.501 4.501 0 0 0-1.423-.23H3.75"
-										/>
-									</svg>
-								</button>
-								<button
-									type="button"
-									title="Thumbs down"
-									className={votes[msg.id] === "dislike" ? "active" : ""}
-									onClick={() => handleVote(msg.id, "dislike")}
-								>
-									<svg
-										xmlns="http://www.w3.org/2000/svg"
-										fill="none"
-										viewBox="0 0 24 24"
-										strokeWidth={1.5}
-										stroke="currentColor"
-									>
-										<path
-											strokeLinecap="round"
-											strokeLinejoin="round"
-											d="M17.367 13.75c-.806 0-1.533.446-2.031 1.08a9.041 9.041 0 0 1-2.861 2.4c-.723.384-1.35.956-1.653 1.715a4.498 4.498 0 0 0-.322 1.672v.633a.75.75 0 0 1-.75.75 2.25 2.25 0 0 1-2.25-2.25c0-1.152.26-2.243.723-3.218.266-.558-.107-1.282-.725-1.282m0 0H4.372c-1.026 0-1.945-.694-2.054-1.715A12.134 12.134 0 0 1 2.25 12c0-2.848.992-5.464 2.649-7.521C5.287 3.997 5.886 3.75 6.504 3.75h4.016c.483 0 .964.078 1.423.23l3.114 1.04a4.501 4.501 0 0 0 1.423.23h2.27"
-										/>
-									</svg>
-								</button>
-							</div>
-						)}
-					</div>
-				))}
-				{/* Show status indicator only when asking but no streaming message yet */}
-				{isAsking && !messages.some((m) => m.isStreaming) && (
-					<div className="message message-assistant">
-						<div className="message-role">Assistant</div>
-						<div className="thinking-status">
-							{progress.type === "thinking" && (
-								<>
-									<span className="thinking-dots">
-										<span>.</span>
-										<span>.</span>
-										<span>.</span>
-									</span>
-									Thinking
-								</>
-							)}
-							{progress.type === "compaction" && (
-								<>
-									<span className="compaction-icon">📝</span>
-									Compacting context...
-									{progress.tokensBefore && progress.tokensAfter && (
-										<span className="compaction-info">
-											{" "}
-											({progress.tokensBefore.toLocaleString()} → {progress.tokensAfter.toLocaleString()} tokens)
-										</span>
-									)}
-								</>
-							)}
-							{progress.type === "tool" && (
-								<>
-									<span className="tool-icon">&#8594;</span>
-									{progress.toolName}
-								</>
-							)}
-							{progress.type === "responding" && "Writing response..."}
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										d="M17.367 13.75c-.806 0-1.533.446-2.031 1.08a9.041 9.041 0 0 1-2.861 2.4c-.723.384-1.35.956-1.653 1.715a4.498 4.498 0 0 0-.322 1.672v.633a.75.75 0 0 1-.75.75 2.25 2.25 0 0 1-2.25-2.25c0-1.152.26-2.243.723-3.218.266-.558-.107-1.282-.725-1.282m0 0H4.372c-1.026 0-1.945-.694-2.054-1.715A12.134 12.134 0 0 1 2.25 12c0-2.848.992-5.464 2.649-7.521C5.287 3.997 5.886 3.75 6.504 3.75h4.016c.483 0 .964.078 1.423.23l3.114 1.04a4.501 4.501 0 0 0 1.423.23h2.27"
+									/>
+								</svg>
+							</button>
 						</div>
+					)}
+				</div>
+			))}
+			{/* Show status indicator only when asking but no streaming message yet */}
+			{isAsking && !messages.some((m) => m.isStreaming) && (
+				<div className="message message-assistant">
+					<div className="message-role">Assistant</div>
+					<div className="thinking-status">
+						{progress.type === "thinking" && (
+							<>
+								<span className="thinking-dots">
+									<span>.</span>
+									<span>.</span>
+									<span>.</span>
+								</span>
+								Thinking
+							</>
+						)}
+						{progress.type === "compaction" && (
+							<>
+								<span className="compaction-icon">📝</span>
+								Compacting context...
+								{progress.tokensBefore && progress.tokensAfter && (
+									<span className="compaction-info">
+										{" "}
+										({progress.tokensBefore.toLocaleString()} → {progress.tokensAfter.toLocaleString()} tokens)
+									</span>
+								)}
+							</>
+						)}
+						{progress.type === "tool" && (
+							<>
+								<span className="tool-icon">&#8594;</span>
+								{progress.toolName}
+							</>
+						)}
+						{progress.type === "responding" && "Writing response..."}
 					</div>
-				)}
+				</div>
+			)}
 				<div ref={messagesEndRef} />
 			</div>
-			{showGlow && <div className={`streaming-glow${isAutoScrolling ? " streaming-glow-emphatic" : ""}`} />}
+			{showStreamingGlow && (
+				<div className={`streaming-glow ${isAutoScrolling ? "streaming-glow-emphatic" : ""}`} />
+			)}
 		</div>
 	);
 }

--- a/ask-forge-web/src/client/hooks/useWebSocket.ts
+++ b/ask-forge-web/src/client/hooks/useWebSocket.ts
@@ -346,9 +346,16 @@ export function useWebSocket({
 					}
 				} else if (message.type === "cancelled") {
 					stopReleaseLoop();
+					flushTextBuffer();
 
 					if (streamingMessageIdRef.current) {
-						setMessages((prev) => prev.filter((msg) => msg.id !== streamingMessageIdRef.current));
+						setMessages((prev) =>
+							prev.map((msg) =>
+								msg.id === streamingMessageIdRef.current
+									? { ...msg, isStreaming: false }
+									: msg
+							),
+						);
 					}
 
 					streamingMessageIdRef.current = null;
@@ -416,7 +423,7 @@ export function useWebSocket({
 
 		ws.onmessage = handleWsMessage;
 
-		ws.onerror = () => {};
+		ws.onerror = () => { };
 
 		ws.onclose = () => {
 			wsRef.current = null;

--- a/ask-forge-web/src/websocket.ts
+++ b/ask-forge-web/src/websocket.ts
@@ -17,6 +17,9 @@ type WSMessage =
 // Track in-flight requests for cancellation
 const activeRequests = new Map<string, AbortController>();
 
+// Track requestId -> sessionId mapping for cancellation
+const requestToSession = new Map<string, string>();
+
 // Buffer for streaming output per session - allows resuming after page refresh
 interface StreamBuffer {
 	requestId: string;
@@ -79,6 +82,18 @@ export const websocketHandler = {
 				if (controller) {
 					controller.abort();
 					activeRequests.delete(data.requestId);
+
+					// Mark the stream buffer as completed to allow new requests
+					const sessionId = requestToSession.get(data.requestId);
+					if (sessionId) {
+						const buffer = streamBuffers.get(sessionId);
+						if (buffer) {
+							buffer.completed = true;
+							buffer.completedAt = Date.now();
+						}
+						requestToSession.delete(data.requestId);
+					}
+
 					ws.send(JSON.stringify({ type: "cancelled", requestId: data.requestId }));
 				}
 				return;
@@ -313,6 +328,9 @@ async function handleAsk(ws: ServerWebSocket<WebSocketData>, requestId: string, 
 	const abortController = new AbortController();
 	activeRequests.set(requestId, abortController);
 
+	// Track requestId -> sessionId mapping
+	requestToSession.set(requestId, sessionId);
+
 	// Initialize stream buffer for this session
 	streamBuffers.set(sessionId, {
 		requestId,
@@ -371,5 +389,6 @@ async function handleAsk(ws: ServerWebSocket<WebSocketData>, requestId: string, 
 		}
 	} finally {
 		activeRequests.delete(requestId);
+		requestToSession.delete(requestId);
 	}
 }


### PR DESCRIPTION
Implements #10 

Client-side Fixes:
  - Fixed streaming state management: `isStreaming` now correctly set to false on
  completion
  - `handleCancel` now immediately cleans up all streaming state without waiting for
  server response
  - Added `currentRequestIdRef.current !== null` check to prevent race conditions in
  `handleSend` and `handleResend`
  - Cancelled messages now properly marked as not streaming instead of being removed

  Server-side improvements:
  - Added requestId → sessionId mapping for proper cancellation cleanup
