### PR TITLE
Add data usage notice to landing page

### DIFF
--- a/ask-forge-web/public/index.html
+++ b/ask-forge-web/public/index.html
@@ -1905,6 +1905,30 @@
 			cursor: not-allowed;
 		}
 
+		/* Data Notice */
+		.data-notice {
+			margin-top: 24px;
+			padding: 12px 16px;
+			background: rgba(236, 72, 153, 0.06);
+			border: 1px solid rgba(236, 72, 153, 0.2);
+			border-radius: 8px;
+			color: var(--text-secondary);
+			font-size: 13px;
+			text-align: center;
+			line-height: 1.6;
+		}
+
+		.data-notice a {
+			color: var(--accent-pink);
+			font-weight: 600;
+			text-decoration: underline;
+			text-underline-offset: 2px;
+		}
+
+		.data-notice a:hover {
+			color: var(--accent-pink-hover);
+		}
+
 	</style>
 </head>
 <body>

--- a/ask-forge-web/src/client/components/ConnectPhase.tsx
+++ b/ask-forge-web/src/client/components/ConnectPhase.tsx
@@ -65,6 +65,17 @@ export function ConnectPhase({
 							Sign in with GitHub
 						</button>
 						<p className="hint">Sign in to start exploring repositories</p>
+						<p className="data-notice">
+							All conversations are used for improving ask forge and may end up in a{" "}
+							<a
+								href="https://huggingface.co/datasets/nilenso/ask-forge-eval-dataset"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								public dataset
+							</a>
+							.
+						</p>
 					</div>
 				</div>
 			</div>
@@ -103,6 +114,17 @@ export function ConnectPhase({
 					{bookmarkletError && <div className="error-message">{bookmarkletError}</div>}
 
 					<p className="hint">Paste a GitHub, GitLab, or Bitbucket URL</p>
+					<p className="data-notice">
+						All conversations are used for improving ask forge and may end up in a{" "}
+						<a
+							href="https://huggingface.co/datasets/nilenso/ask-forge-eval-dataset"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							public dataset
+						</a>
+						.
+					</p>
 				</div>
 				{buildTime && (
 					<div className="deploy-info">


### PR DESCRIPTION
Adds a notice to the landing page (both logged-out and logged-in views) informing users that all conversations are used for improving ask forge and may end up in a [public dataset](https://huggingface.co/datasets/nilenso/ask-forge-eval-dataset).