### PR TITLE
jadoo: add GitHub CI pipeline for deploy via SSH + systemd

### DIFF
--- a/.github/workflows/jadoo-deploy.yml
+++ b/.github/workflows/jadoo-deploy.yml
@@ -1,0 +1,86 @@
+name: Test & Deploy Jadoo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "jadoo/**"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: jadoo
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: jadoo
+        run: bun test test/*.test.ts
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: jadoo-prod
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.JADOO_SSH_KEY }}
+          DEPLOY_HOST: ${{ secrets.JADOO_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy to server
+        env:
+          DEPLOY_HOST: ${{ secrets.JADOO_HOST }}
+          DOTENV: ${{ secrets.JADOO_DOTENV }}
+        run: |
+          rsync -az --delete \
+            --exclude='node_modules' \
+            --exclude='data' \
+            --exclude='.env' \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            jadoo/ root@"$DEPLOY_HOST":/opt/jadoo/
+
+          # Write .env from secret
+          echo "$DOTENV" | ssh -i ~/.ssh/deploy_key root@"$DEPLOY_HOST" \
+            "cat > /opt/jadoo/.env && chmod 600 /opt/jadoo/.env"
+
+          ssh -i ~/.ssh/deploy_key root@"$DEPLOY_HOST" bash -s <<'EOF'
+            set -e
+
+            # Install Bun if missing
+            if ! command -v bun &>/dev/null && [ ! -f ~/.bun/bin/bun ]; then
+              curl -fsSL https://bun.sh/install | bash
+            fi
+            export PATH="$HOME/.bun/bin:$PATH"
+
+            cd /opt/jadoo
+            mkdir -p data
+            bun install --frozen-lockfile
+
+            # Install & reload systemd service
+            cp deploy/jadoo.service /etc/systemd/system/jadoo.service
+            systemctl daemon-reload
+            systemctl enable jadoo
+            systemctl restart jadoo
+
+            echo "Jadoo deployed successfully"
+          EOF
+
+      - name: Cleanup SSH
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/jadoo/deploy/jadoo.service
+++ b/jadoo/deploy/jadoo.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Jadoo Slack Bot
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/jadoo
+ExecStart=/root/.bun/bin/bun src/index.ts
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=/opt/jadoo/.env
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/opt/jadoo/data
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow to test and deploy jadoo to a server on every push to `main` that touches `jadoo/`.

## How it works

**Test job:** Runs `bun test` (136 unit tests) on every push.

**Deploy job:** (requires `jadoo-prod` environment)
1. Rsyncs `jadoo/` to `/opt/jadoo/` on the server (excluding `node_modules`, `data`, `.env`)
2. Writes `.env` from the `JADOO_DOTENV` secret
3. Installs Bun if missing, runs `bun install`
4. Installs/reloads the systemd service, restarts

**Systemd service** (`jadoo/deploy/jadoo.service`):
- Runs as `bun src/index.ts` from `/opt/jadoo`
- Auto-restarts on failure (5s delay)
- Reads env from `/opt/jadoo/.env`
- Basic hardening (`NoNewPrivileges`, `ProtectSystem=strict`)

## Secrets needed

Add these to the `jadoo-prod` GitHub environment:

| Secret | Description |
|--------|-------------|
| `JADOO_HOST` | Server hostname or IP |
| `JADOO_SSH_KEY` | SSH private key (root access) |
| `JADOO_DOTENV` | Contents of the `.env` file (all env vars) |
