### PR TITLE
jadoo: create full-day leave events as all-day gcal entries

### DIFF
--- a/jadoo/src/interfaces/calendar.ts
+++ b/jadoo/src/interfaces/calendar.ts
@@ -9,6 +9,7 @@ export interface CalendarEvent {
 	description?: string;
 	start: Date;
 	end: Date;
+	allDay?: boolean;
 	attendees?: string[];
 	location?: string;
 }
@@ -18,6 +19,7 @@ export interface CreateEventRequest {
 	description?: string;
 	start: Date;
 	end: Date;
+	allDay?: boolean;
 	attendees?: string[];
 	location?: string;
 }

--- a/jadoo/src/services/calendar/gcal-service.ts
+++ b/jadoo/src/services/calendar/gcal-service.ts
@@ -12,12 +12,14 @@ import type {
 } from "../../interfaces/calendar.js";
 
 function toCalendarEvent(event: calendar_v3.Schema$Event): CalendarEvent {
+	const allDay = Boolean(event.start?.date && !event.start?.dateTime);
 	return {
 		id: event.id ?? "",
 		summary: event.summary ?? "",
 		description: event.description ?? undefined,
 		start: new Date(event.start?.dateTime ?? event.start?.date ?? ""),
 		end: new Date(event.end?.dateTime ?? event.end?.date ?? ""),
+		allDay,
 		attendees: event.attendees?.map((a) => a.email ?? "").filter(Boolean),
 		location: event.location ?? undefined,
 	};
@@ -59,8 +61,12 @@ export class GCalService implements CalendarService {
 			requestBody: {
 				summary: request.summary,
 				description: request.description,
-				start: { dateTime: request.start.toISOString() },
-				end: { dateTime: request.end.toISOString() },
+				start: request.allDay
+					? { date: request.start.toISOString().slice(0, 10) }
+					: { dateTime: request.start.toISOString() },
+				end: request.allDay
+					? { date: request.end.toISOString().slice(0, 10) }
+					: { dateTime: request.end.toISOString() },
 				attendees: request.attendees?.map((email) => ({ email })),
 				location: request.location,
 			},

--- a/jadoo/src/worker.ts
+++ b/jadoo/src/worker.ts
@@ -278,20 +278,26 @@ export class BackgroundWorker {
 			let stage: LeaveProcessingFailure["stage"] = "calendar";
 			try {
 				// Sync to Calendar
+				const isFullDayLeave = payload.leaveType === "full";
 				const start = new Date(`${date}T00:00:00`);
-				const end = new Date(`${date}T23:59:59`);
+				const end = isFullDayLeave ? new Date(`${date}T00:00:00`) : new Date(`${date}T23:59:59`);
+				if (isFullDayLeave) {
+					end.setDate(end.getDate() + 1);
+				}
 				logWorker("creating calendar event", {
 					actionId: action.id,
 					recordId: record.id,
 					date,
 					start: start.toISOString(),
 					end: end.toISOString(),
+					allDay: isFullDayLeave,
 				});
 				const calEvent = await this.calendar.createEvent({
 					summary: `${user.slack_display_name} — ${payload.category} (${payload.leaveType})`,
 					description: payload.reason,
 					start,
 					end,
+					allDay: isFullDayLeave,
 				});
 				logWorker("calendar event created", {
 					actionId: action.id,

--- a/jadoo/test/mocks.ts
+++ b/jadoo/test/mocks.ts
@@ -95,6 +95,7 @@ export class MockCalendarService implements CalendarService {
 			description: request.description,
 			start: request.start,
 			end: request.end,
+			allDay: request.allDay,
 			attendees: request.attendees,
 			location: request.location,
 		};

--- a/jadoo/test/worker.test.ts
+++ b/jadoo/test/worker.test.ts
@@ -83,6 +83,9 @@ describe("processTick — create_leave", () => {
 		expect(calendar.createdEvents).toHaveLength(1);
 		expect(calendar.createdEvents[0].summary).toContain("Alice");
 		expect(calendar.createdEvents[0].summary).toContain("vacation");
+		expect(calendar.createdEvents[0].allDay).toBe(true);
+		expect(calendar.createdEvents[0].start.toISOString().slice(0, 10)).toBe("2026-04-01");
+		expect(calendar.createdEvents[0].end.toISOString().slice(0, 10)).toBe("2026-04-02");
 
 		// Harvest entry created
 		expect(harvest.createdEntries).toHaveLength(1);
@@ -257,6 +260,8 @@ describe("processTick — create_leave", () => {
 		expect(getPendingActionById(db, a1.id)?.status).toBe("completed");
 		expect(getPendingActionById(db, a2.id)?.status).toBe("completed");
 		expect(calendar.createdEvents).toHaveLength(2);
+		expect(calendar.createdEvents[0].allDay).toBe(true);
+		expect(calendar.createdEvents[1].allDay).toBeFalsy();
 		expect(harvest.createdEntries).toHaveLength(2);
 	});
 });


### PR DESCRIPTION
## Summary
- create full-day leave events in Google Calendar as all-day events
- keep half-day leave entries as timed events
- add/update tests for all-day calendar behavior

## Testing
- bun test test/worker.test.ts test/interfaces.test.ts