### PR TITLE
Jadoo: support time-specific leave and button-only leave resolution

### DIFF
--- a/jadoo/AGENTS.md
+++ b/jadoo/AGENTS.md
@@ -1,0 +1,32 @@
+Default to using Bun instead of Node.js.
+
+> **Note**: When changing behavior, workflows, schema, migrations, or setup steps, update `README.md` accordingly.
+
+- Use `bun install` instead of `npm install` / `yarn` / `pnpm`
+- Use `bun run <script>` instead of `npm run <script>` / `yarn run` / `pnpm run`
+- Use `bun test` for tests
+- Bun automatically loads `.env`, so don't add dotenv unless there is a strong reason
+
+## Required validation after code changes
+
+After making code changes in `jadoo`, run these checks yourself before finishing:
+
+1. `~/.bun/bin/bun test test/*.test.ts`
+2. `~/.bun/bin/bun x @biomejs/biome check .`
+
+If Biome reports formatting issues, fix them before finishing.
+If you change migrations, parsing, worker logic, or Slack interaction flows, make sure the relevant tests are updated or added.
+
+## Project notes
+
+- Runtime: **Bun**
+- Web framework: **Hono**
+- Database: SQLite via `bun:sqlite`
+- Migrations: `litem8`
+- Formatting/linting: **Biome**
+- Testing: `bun:test`
+
+## Leave workflow notes
+
+- Prefer Slack Block Kit buttons for ambiguous leave flows rather than asking users for open-ended follow-up text.
+- Keep worker, parser schema, persistence, and tests aligned when adding new leave types or payload fields.

--- a/jadoo/README.md
+++ b/jadoo/README.md
@@ -127,7 +127,8 @@ The `SlackService` interface is explicitly Slack-specific (not a generic "messag
 SQLite via `bun:sqlite`. Three tables:
 
 - **users** — Slack ↔ Harvest ↔ email mapping, timezone
-- **leave_records** — date, type (full/half), category (vacation/sick), sync status, calendar/harvest IDs
+- **leave_records** — date, type (full/half/time-specific), optional start/end time,
+  category (vacation/sick), sync status, calendar/harvest IDs
 - **pending_actions** — confirmation flow state machine with expiry, JSON payload, thread context
 
 Typed repository functions in `src/db/` — no ORM, plain SQL queries with TypeScript interfaces.

--- a/jadoo/biome.json
+++ b/jadoo/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"files": {
 		"includes": ["**", "!node_modules"]
 	},

--- a/jadoo/bun.lock
+++ b/jadoo/bun.lock
@@ -12,7 +12,7 @@
         "smol-toml": "^1.6.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.7",
+        "@biomejs/biome": "2.4.16",
         "@types/bun": "^1.3.11",
         "typescript": "^6.0.2",
       },
@@ -95,23 +95,23 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@google/genai": ["@google/genai@1.47.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-0VV7AaXm5rQu3oRHNZNEubRAOL2lv5u+YA72eWnDwcOx3B1jFRbvtgL4drRHlocRHOnludvr3xmbQGbR+/RQAQ=="],
 

--- a/jadoo/migrations/002_create_leave_records.sql
+++ b/jadoo/migrations/002_create_leave_records.sql
@@ -1,5 +1,5 @@
 -- Leave records: one row per user per leave day
--- leave_type: 'full' | 'half_am' | 'half_pm'
+-- leave_type: 'full' | 'half_am' | 'half_pm' | 'specific'
 -- leave_category: 'vacation' | 'sick'
 -- status: 'pending' | 'confirmed' | 'completed' | 'failed' | 'cancelled'
 CREATE TABLE leave_records (

--- a/jadoo/migrations/004_add_leave_record_time_fields.sql
+++ b/jadoo/migrations/004_add_leave_record_time_fields.sql
@@ -1,0 +1,3 @@
+-- Add optional time fields for time-specific leave requests
+ALTER TABLE leave_records ADD COLUMN start_time TEXT;
+ALTER TABLE leave_records ADD COLUMN end_time TEXT;

--- a/jadoo/package.json
+++ b/jadoo/package.json
@@ -11,7 +11,7 @@
 		"test": "bun test test/*.test.ts",
 		"test:integration": "bun test test/integration/",
 		"test:all": "bun test",
-		"check": "bunx biome check --write ."
+		"check": "biome check --write ."
 	},
 	"dependencies": {
 		"@googleapis/calendar": "^14.2.0",
@@ -21,7 +21,7 @@
 		"smol-toml": "^1.6.1"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.7",
+		"@biomejs/biome": "2.4.16",
 		"@types/bun": "^1.3.11",
 		"typescript": "^6.0.2"
 	}

--- a/jadoo/src/db/index.ts
+++ b/jadoo/src/db/index.ts
@@ -2,6 +2,7 @@ export type { DatabaseOptions } from "./database.js";
 export { openDatabase, runMigrations } from "./database.js";
 export {
 	createLeaveRecord,
+	getCancelableLeaveRecordsByUser,
 	getLeaveRecordById,
 	getLeaveRecordsByPendingAction,
 	getLeaveRecordsByStatus,

--- a/jadoo/src/db/leave-records.ts
+++ b/jadoo/src/db/leave-records.ts
@@ -11,6 +11,8 @@ export function createLeaveRecord(
 		userId: number;
 		date: string;
 		leaveType?: string;
+		startTime?: string | null;
+		endTime?: string | null;
 		leaveCategory?: string;
 		slackMessageTs?: string | null;
 		slackChannelId?: string | null;
@@ -19,12 +21,26 @@ export function createLeaveRecord(
 ): DbLeaveRecord {
 	const now = new Date().toISOString();
 	db.run(
-		`INSERT INTO leave_records (user_id, date, leave_type, leave_category, slack_message_ts, slack_channel_id, status, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO leave_records (
+			user_id,
+			date,
+			leave_type,
+			start_time,
+			end_time,
+			leave_category,
+			slack_message_ts,
+			slack_channel_id,
+			status,
+			created_at,
+			updated_at
+		)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		[
 			params.userId,
 			params.date,
 			params.leaveType ?? "full",
+			params.startTime ?? null,
+			params.endTime ?? null,
 			params.leaveCategory ?? "vacation",
 			params.slackMessageTs ?? null,
 			params.slackChannelId ?? null,
@@ -44,6 +60,8 @@ export function upsertLeaveRecord(
 		userId: number;
 		date: string;
 		leaveType?: string;
+		startTime?: string | null;
+		endTime?: string | null;
 		leaveCategory?: string;
 		slackMessageTs?: string | null;
 		slackChannelId?: string | null;
@@ -52,10 +70,24 @@ export function upsertLeaveRecord(
 ): DbLeaveRecord {
 	const now = new Date().toISOString();
 	const _result = db.run(
-		`INSERT INTO leave_records (user_id, date, leave_type, leave_category, slack_message_ts, slack_channel_id, status, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO leave_records (
+			user_id,
+			date,
+			leave_type,
+			start_time,
+			end_time,
+			leave_category,
+			slack_message_ts,
+			slack_channel_id,
+			status,
+			created_at,
+			updated_at
+		)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(user_id, date) DO UPDATE SET
 		   leave_type = excluded.leave_type,
+		   start_time = excluded.start_time,
+		   end_time = excluded.end_time,
 		   leave_category = excluded.leave_category,
 		   status = excluded.status,
 		   error_message = NULL,
@@ -64,6 +96,8 @@ export function upsertLeaveRecord(
 			params.userId,
 			params.date,
 			params.leaveType ?? "full",
+			params.startTime ?? null,
+			params.endTime ?? null,
 			params.leaveCategory ?? "vacation",
 			params.slackMessageTs ?? null,
 			params.slackChannelId ?? null,
@@ -154,4 +188,21 @@ export function getLeaveRecordsByPendingAction(db: Database, userId: number, dat
 			`SELECT * FROM leave_records WHERE user_id = ? AND date IN (${placeholders}) ORDER BY date`,
 		)
 		.all(userId, ...dates);
+}
+
+export function getCancelableLeaveRecordsByUser(
+	db: Database,
+	userId: number,
+	pivotDate: string,
+	limit: number = 5,
+): DbLeaveRecord[] {
+	return db
+		.query<DbLeaveRecord, [number, string, number]>(
+			`SELECT * FROM leave_records
+			 WHERE user_id = ?
+			 AND status IN ('confirmed', 'completed')
+			 ORDER BY CASE WHEN date >= ? THEN 0 ELSE 1 END, date ASC
+			 LIMIT ?`,
+		)
+		.all(userId, pivotDate, limit);
 }

--- a/jadoo/src/db/types.ts
+++ b/jadoo/src/db/types.ts
@@ -19,7 +19,9 @@ export interface DbLeaveRecord {
 	id: number;
 	user_id: number;
 	date: string; // YYYY-MM-DD
-	leave_type: string; // 'full' | 'half_am' | 'half_pm'
+	leave_type: string; // 'full' | 'half_am' | 'half_pm' | 'specific'
+	start_time: string | null; // HH:MM for time-specific leave
+	end_time: string | null; // HH:MM for time-specific leave
 	leave_category: string; // 'vacation' | 'sick'
 	slack_message_ts: string | null;
 	slack_channel_id: string | null;

--- a/jadoo/src/interfaces/harvest.ts
+++ b/jadoo/src/interfaces/harvest.ts
@@ -3,7 +3,7 @@
  * Abstracts over the Harvest API for leave time entry management.
  */
 
-export type LeaveType = "full" | "half_am" | "half_pm";
+export type LeaveType = "full" | "half_am" | "half_pm" | "specific";
 export type LeaveCategory = "vacation" | "sick";
 
 export interface HarvestTimeEntry {
@@ -22,6 +22,7 @@ export interface CreateTimeEntryRequest {
 	date: string; // YYYY-MM-DD
 	leaveType: LeaveType;
 	category: LeaveCategory;
+	hours?: number;
 	notes?: string;
 }
 

--- a/jadoo/src/plugins/leave/blocks.ts
+++ b/jadoo/src/plugins/leave/blocks.ts
@@ -4,17 +4,83 @@ import type { LeaveDateSchema } from "./schema.js";
 
 type LeaveDate = Static<typeof LeaveDateSchema>;
 
-function formatLeaveDate(ld: LeaveDate): string {
-	const date = new Date(`${ld.date}T12:00:00Z`); // use noon to avoid tz issues
-	const dateStr = date.toLocaleDateString("en-US", {
+export interface InteractiveOption {
+	text: string;
+	value: string;
+	actionId: string;
+	style?: "primary" | "danger";
+}
+
+function formatCalendarDate(dateText: string): string {
+	const date = new Date(`${dateText}T12:00:00Z`);
+	return date.toLocaleDateString("en-US", {
 		weekday: "short",
 		month: "short",
 		day: "numeric",
 		year: "numeric",
 	});
-	const typeStr = ld.type === "full" ? "Full day" : ld.type === "half_am" ? "First half" : "Second half";
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+	const result: T[][] = [];
+	for (let i = 0; i < items.length; i += size) {
+		result.push(items.slice(i, i + size));
+	}
+	return result;
+}
+
+export function buildInteractiveChoiceBlocks(text: string, options: InteractiveOption[]): Block[] {
+	const blocks: Block[] = [
+		{
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text,
+			},
+		},
+	];
+
+	for (const optionGroup of chunk(options, 5)) {
+		blocks.push({
+			type: "actions",
+			elements: optionGroup.map((option) => ({
+				type: "button",
+				text: {
+					type: "plain_text",
+					text: option.text,
+					emoji: true,
+				},
+				value: option.value,
+				action_id: option.actionId,
+				...(option.style ? { style: option.style } : {}),
+			})),
+		});
+	}
+
+	return blocks;
+}
+
+function formatLeaveDate(ld: LeaveDate): string {
+	const typeStr =
+		ld.type === "full"
+			? "Full day"
+			: ld.type === "half_am"
+				? "First half"
+				: ld.type === "half_pm"
+					? "Second half"
+					: `Time specific (${ld.start_time ?? "?"}-${ld.end_time ?? "?"})`;
 	const categoryStr = ld.category.charAt(0).toUpperCase() + ld.category.slice(1);
-	return `• ${dateStr} — ${typeStr} (${categoryStr})`;
+	return `• ${formatCalendarDate(ld.date)} — ${typeStr} (${categoryStr})`;
+}
+
+export function formatLeaveDateLabel(dateText: string): string {
+	return formatCalendarDate(dateText);
+}
+
+export function formatLeaveDateRangeLabel(dates: string[]): string {
+	if (dates.length === 0) return "No dates";
+	if (dates.length === 1) return formatLeaveDateLabel(dates[0]);
+	return `${formatLeaveDateLabel(dates[0])} → ${formatLeaveDateLabel(dates[dates.length - 1])}`;
 }
 
 export function buildConfirmationBlocks(dates: LeaveDate[], actionId: string, hasConflict: boolean = false): Block[] {
@@ -60,16 +126,15 @@ export function buildConfirmationBlocks(dates: LeaveDate[], actionId: string, ha
 	];
 }
 
-export function buildCancellationClarificationBlocks(): Block[] {
-	return [
-		{
-			type: "section",
-			text: {
-				type: "mrkdwn",
-				text: '🔄 Which leave dates would you like to cancel?\n\nPlease reply in this thread with the specific dates, e.g., "cancel my leave on Jan 3" or "cancel Jan 3-5"',
-			},
-		},
-	];
+export function buildLeaveOptionsBlocks(options: InteractiveOption[]): Block[] {
+	return buildInteractiveChoiceBlocks(
+		"🧭 I couldn't turn that into a final leave action automatically. Choose one of the options below.",
+		options,
+	);
+}
+
+export function buildCancellationSelectionBlocks(options: InteractiveOption[]): Block[] {
+	return buildInteractiveChoiceBlocks("🔄 Select a leave entry to cancel.", options);
 }
 
 export function buildCancellationConfirmationBlocks(dates: LeaveDate[], actionId: string): Block[] {

--- a/jadoo/src/plugins/leave/index.ts
+++ b/jadoo/src/plugins/leave/index.ts
@@ -170,7 +170,10 @@ function formatMinutesAsTime(totalMinutes: number): string {
 	return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
 }
 
-function buildSpecificLeaveTimeRanges(startTime?: string, endTime?: string): Array<{ startTime: string; endTime: string }> {
+function buildSpecificLeaveTimeRanges(
+	startTime?: string,
+	endTime?: string,
+): Array<{ startTime: string; endTime: string }> {
 	const options: Array<{ startTime: string; endTime: string }> = [];
 	const durations = [120, 180, 240];
 

--- a/jadoo/src/plugins/leave/index.ts
+++ b/jadoo/src/plugins/leave/index.ts
@@ -1,6 +1,7 @@
 import type { Database } from "bun:sqlite";
+import type { Static } from "@sinclair/typebox";
 import type { PluginConfig, PluginConfigSchema } from "../../config/plugin-config.js";
-import { getLeaveRecordsByUserAndDates } from "../../db/leave-records.js";
+import { getCancelableLeaveRecordsByUser, getLeaveRecordsByUserAndDates } from "../../db/leave-records.js";
 import {
 	createPendingAction,
 	getPendingActionsForThread,
@@ -10,15 +11,20 @@ import {
 import { createUser, getUserBySlackId } from "../../db/users.js";
 import type { BotContext, Plugin } from "../../interfaces/plugin.js";
 import {
-	buildCancellationClarificationBlocks,
 	buildCancellationConfirmationBlocks,
+	buildCancellationSelectionBlocks,
 	buildConfirmationBlocks,
+	buildInteractiveChoiceBlocks,
+	buildLeaveOptionsBlocks,
+	formatLeaveDateLabel,
+	formatLeaveDateRangeLabel,
+	type InteractiveOption,
 } from "./blocks.js";
 import { ParsedLeaveSchema } from "./schema.js";
 
 function getFutureExpiry(): string {
 	const date = new Date();
-	date.setHours(date.getHours() + 1); // 1 hour expiry
+	date.setHours(date.getHours() + 1);
 	return date.toISOString();
 }
 
@@ -28,6 +34,328 @@ function logLeave(message: string, details?: Record<string, unknown>): void {
 
 function isEnabled(value: string | undefined): boolean {
 	return ["1", "true", "yes", "on"].includes((value ?? "").trim().toLowerCase());
+}
+
+type ParsedLeave = Static<typeof ParsedLeaveSchema>;
+type LeaveType = "full" | "half_am" | "half_pm" | "specific";
+type LeaveCategory = "vacation" | "sick";
+
+interface CreateSelectionPayload {
+	kind: "create";
+	dates: string[];
+	leaveType: LeaveType;
+	startTime?: string;
+	endTime?: string;
+	category: LeaveCategory;
+	reason: string;
+	sourceMessageTs: string;
+	sourceThreadTs?: string;
+}
+
+interface CancelSelectionPayload {
+	kind: "cancel";
+	dates: string[];
+	sourceMessageTs: string;
+	sourceThreadTs?: string;
+}
+
+interface DismissSelectionPayload {
+	kind: "dismiss";
+	message: string;
+}
+
+type SelectionPayload = CreateSelectionPayload | CancelSelectionPayload | DismissSelectionPayload;
+
+function encodeSelectionPayload(payload: SelectionPayload): string {
+	return JSON.stringify(payload);
+}
+
+function decodeSelectionPayload(value: string): SelectionPayload | null {
+	try {
+		return JSON.parse(value) as SelectionPayload;
+	} catch {
+		return null;
+	}
+}
+
+function getDatePartsInTimeZone(now: Date, timeZone: string): { year: number; month: number; day: number } {
+	const formatter = new Intl.DateTimeFormat("en-US", {
+		timeZone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	});
+	const parts = formatter.formatToParts(now);
+	const get = (type: "year" | "month" | "day") => Number(parts.find((part) => part.type === type)?.value ?? "0");
+	return { year: get("year"), month: get("month"), day: get("day") };
+}
+
+function formatYmd(year: number, month: number, day: number): string {
+	return `${year.toString().padStart(4, "0")}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
+}
+
+function localDateStringInTimeZone(timeZone: string, now: Date = new Date()): string {
+	const { year, month, day } = getDatePartsInTimeZone(now, timeZone || "UTC");
+	return formatYmd(year, month, day);
+}
+
+function addDays(dateText: string, days: number): string {
+	const [year, month, day] = dateText.split("-").map(Number);
+	const date = new Date(Date.UTC(year, month - 1, day));
+	date.setUTCDate(date.getUTCDate() + days);
+	return formatYmd(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
+}
+
+function getWeekday(dateText: string): number {
+	const [year, month, day] = dateText.split("-").map(Number);
+	return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+}
+
+function nextWeekday(dateText: string, targetWeekday: number, forceFollowingWeek: boolean): string {
+	const currentWeekday = getWeekday(dateText);
+	let diff = (targetWeekday - currentWeekday + 7) % 7;
+	if (diff === 0) diff = 7;
+	if (forceFollowingWeek && diff < 7) diff += 7;
+	return addDays(dateText, diff);
+}
+
+function weekdaySpan(dateText: string, startWeekday: number, endWeekday: number): string[] {
+	const dates: string[] = [];
+	let cursor = dateText;
+	while (getWeekday(cursor) !== startWeekday) {
+		cursor = addDays(cursor, 1);
+	}
+	while (getWeekday(cursor) <= endWeekday) {
+		dates.push(cursor);
+		cursor = addDays(cursor, 1);
+	}
+	return dates;
+}
+
+function inferLeaveType(text: string): LeaveType {
+	const lowerText = text.toLowerCase();
+	if (lowerText.includes("first half") || lowerText.includes("morning") || lowerText.includes("half day first")) {
+		return "half_am";
+	}
+	if (lowerText.includes("second half") || lowerText.includes("afternoon") || lowerText.includes("half day second")) {
+		return "half_pm";
+	}
+	return "full";
+}
+
+function inferLeaveCategory(text: string): LeaveCategory {
+	const lowerText = text.toLowerCase();
+	if (/\b(sick|fever|ill|unwell|doctor|medical)\b/.test(lowerText)) {
+		return "sick";
+	}
+	return "vacation";
+}
+
+function isSpecificLeaveMissingTime(leaveType?: LeaveType, startTime?: string, endTime?: string): boolean {
+	return leaveType === "specific" && (!startTime || !endTime);
+}
+
+function parseTimeToMinutes(time: string): number {
+	const match = /^(\d{2}):(\d{2})$/.exec(time);
+	if (!match) return Number.NaN;
+	const hours = Number(match[1]);
+	const minutes = Number(match[2]);
+	if (hours > 23 || minutes > 59) return Number.NaN;
+	return hours * 60 + minutes;
+}
+
+function formatMinutesAsTime(totalMinutes: number): string {
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
+}
+
+function buildSpecificLeaveTimeRanges(startTime?: string, endTime?: string): Array<{ startTime: string; endTime: string }> {
+	const options: Array<{ startTime: string; endTime: string }> = [];
+	const durations = [120, 180, 240];
+
+	if (startTime && !endTime) {
+		const startMinutes = parseTimeToMinutes(startTime);
+		if (!Number.isNaN(startMinutes)) {
+			for (const duration of durations) {
+				const candidateEnd = startMinutes + duration;
+				if (candidateEnd < 24 * 60) {
+					options.push({ startTime, endTime: formatMinutesAsTime(candidateEnd) });
+				}
+			}
+		}
+	}
+
+	if (!startTime && endTime) {
+		const endMinutes = parseTimeToMinutes(endTime);
+		if (!Number.isNaN(endMinutes)) {
+			for (const duration of durations) {
+				const candidateStart = endMinutes - duration;
+				if (candidateStart >= 0) {
+					options.push({ startTime: formatMinutesAsTime(candidateStart), endTime });
+				}
+			}
+		}
+	}
+
+	return options;
+}
+
+function inferFallbackDateOptions(text: string, timeZone: string): string[][] {
+	const lowerText = text.toLowerCase();
+	const today = localDateStringInTimeZone(timeZone);
+	const options: string[][] = [];
+
+	if (lowerText.includes("day after tomorrow")) {
+		options.push([addDays(today, 2)]);
+	}
+	if (lowerText.includes("tomorrow")) {
+		options.push([addDays(today, 1)]);
+	}
+	if (lowerText.includes("today")) {
+		options.push([today]);
+	}
+	if (lowerText.includes("next week")) {
+		options.push(weekdaySpan(addDays(today, 1), 1, 5));
+	}
+	if (lowerText.includes("this week")) {
+		const thisWeek = weekdaySpan(today, Math.max(getWeekday(today), 1), 5).filter((date) => getWeekday(date) >= 1);
+		if (thisWeek.length > 0) {
+			options.push(thisWeek);
+		}
+	}
+
+	const weekdayMatches: Array<{ name: string; index: number }> = [
+		{ name: "sunday", index: 0 },
+		{ name: "monday", index: 1 },
+		{ name: "tuesday", index: 2 },
+		{ name: "wednesday", index: 3 },
+		{ name: "thursday", index: 4 },
+		{ name: "friday", index: 5 },
+		{ name: "saturday", index: 6 },
+	];
+
+	for (const weekday of weekdayMatches) {
+		if (lowerText.includes(weekday.name)) {
+			options.push([nextWeekday(today, weekday.index, lowerText.includes(`next ${weekday.name}`))]);
+		}
+	}
+
+	if (options.length === 0) {
+		options.push([today], [addDays(today, 1)]);
+	}
+
+	const seen = new Set<string>();
+	return options.filter((dates) => {
+		if (dates.length === 0) return false;
+		const key = dates.join(",");
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}
+
+function getThreadAnchor(sourceMessageTs: string, sourceThreadTs?: string): string {
+	return sourceThreadTs ?? sourceMessageTs;
+}
+
+function toLeaveDates(
+	dates: string[],
+	leaveType: LeaveType,
+	category: LeaveCategory,
+	startTime?: string,
+	endTime?: string,
+) {
+	return dates.map((date) => ({
+		date,
+		type: leaveType,
+		...(leaveType === "specific" ? { start_time: startTime, end_time: endTime } : {}),
+		category,
+	}));
+}
+
+function buildCreateSelectionOptions(
+	messageText: string,
+	parsed: ParsedLeave,
+	timeZone: string,
+	sourceMessageTs: string,
+	sourceThreadTs?: string,
+): InteractiveOption[] {
+	const leaveType = parsed.dates[0]?.type ?? inferLeaveType(messageText);
+	const startTime = parsed.dates[0]?.start_time;
+	const endTime = parsed.dates[0]?.end_time;
+	const category = parsed.dates[0]?.category ?? inferLeaveCategory(messageText);
+	const optionDates: string[][] = [];
+
+	if (parsed.dates.length > 0) {
+		optionDates.push(parsed.dates.map((date) => date.date));
+	}
+	optionDates.push(...inferFallbackDateOptions(messageText, timeZone));
+
+	const seenDates = new Set<string>();
+	const uniqueDates = optionDates.filter((dates) => {
+		if (dates.length === 0) return false;
+		const key = dates.join(",");
+		if (seenDates.has(key)) return false;
+		seenDates.add(key);
+		return true;
+	});
+
+	const options: InteractiveOption[] = [];
+	if (isSpecificLeaveMissingTime(leaveType, startTime, endTime)) {
+		const timeRanges = buildSpecificLeaveTimeRanges(startTime, endTime);
+		for (const dates of uniqueDates) {
+			for (const range of timeRanges) {
+				options.push({
+					text: `Use ${formatLeaveDateRangeLabel(dates)} ${range.startTime}-${range.endTime}`,
+					value: encodeSelectionPayload({
+						kind: "create",
+						dates,
+						leaveType,
+						startTime: range.startTime,
+						endTime: range.endTime,
+						category,
+						reason: parsed.original_text_summary || messageText,
+						sourceMessageTs,
+						sourceThreadTs,
+					}),
+					actionId: "leave_select_create_option",
+					style: "primary",
+				});
+				if (options.length === 4) break;
+			}
+			if (options.length === 4) break;
+		}
+	} else {
+		for (const dates of uniqueDates) {
+			options.push({
+				text: `Use ${formatLeaveDateRangeLabel(dates)}`,
+				value: encodeSelectionPayload({
+					kind: "create",
+					dates,
+					leaveType,
+					startTime,
+					endTime,
+					category,
+					reason: parsed.original_text_summary || messageText,
+					sourceMessageTs,
+					sourceThreadTs,
+				}),
+				actionId: "leave_select_create_option",
+				style: "primary",
+			});
+			if (options.length === 4) break;
+		}
+	}
+
+	options.push({
+		text: "✗ Cancel request",
+		value: encodeSelectionPayload({ kind: "dismiss", message: "❌ Leave request cancelled." }),
+		actionId: "leave_dismiss_option",
+		style: "danger",
+	});
+
+	return options;
 }
 
 export class LeavePlugin implements Plugin {
@@ -54,7 +382,7 @@ export class LeavePlugin implements Plugin {
 
 	async init(ctx: BotContext, config: PluginConfig) {
 		const targetChannelId = config.channelId as string;
-		const triggerKeywords = (config.keywords as string).split(",").map((k) => k.trim().toLowerCase());
+		const triggerKeywords = (config.keywords as string).split(",").map((keyword) => keyword.trim().toLowerCase());
 		const debugLogAllMessages = isEnabled(config.debugLogAllMessages);
 
 		logLeave("initialized leave plugin listener", {
@@ -62,6 +390,219 @@ export class LeavePlugin implements Plugin {
 			triggerKeywords,
 			debugLogAllMessages,
 		});
+
+		const supersedePendingActionsForThread = async (
+			userId: number,
+			channelId: string,
+			threadAnchor: string,
+			messageToKeepTs?: string,
+		) => {
+			const existing = getPendingActionsForThread(this.db, userId, channelId, threadAnchor);
+			const staleActions = existing.filter((action) => action.slack_bot_message_ts !== messageToKeepTs);
+			if (staleActions.length > 0) {
+				logLeave("superseding existing pending actions in thread", {
+					userDbId: userId,
+					channelId,
+					threadTs: threadAnchor,
+					actionIds: staleActions.map((action) => action.id),
+				});
+			}
+
+			for (const action of staleActions) {
+				updatePendingActionStatus(this.db, action.id, "expired");
+				if (action.slack_bot_message_ts) {
+					await ctx.slack.updateMessage(channelId, action.slack_bot_message_ts, {
+						text: "↩️ This request was superseded by a newer one below.",
+						blocks: [
+							{
+								type: "section",
+								text: { type: "mrkdwn", text: "↩️ _This request was superseded by a newer one below._" },
+							},
+						],
+					});
+				}
+			}
+		};
+
+		const presentLeaveOptions = async (params: {
+			channelId: string;
+			sourceMessageTs: string;
+			sourceThreadTs?: string;
+			messageText: string;
+			parsed: ParsedLeave;
+			timeZone: string;
+			replaceMessageTs?: string;
+		}) => {
+			const options = buildCreateSelectionOptions(
+				params.messageText,
+				params.parsed,
+				params.timeZone,
+				params.sourceMessageTs,
+				params.sourceThreadTs,
+			);
+			const blocks = buildLeaveOptionsBlocks(options);
+			if (params.replaceMessageTs) {
+				await ctx.slack.updateMessage(params.channelId, params.replaceMessageTs, {
+					text: "🧭 Choose one of the leave options.",
+					blocks,
+				});
+			} else {
+				await ctx.slack.postMessage(params.channelId, {
+					text: "🧭 Choose one of the leave options.",
+					blocks,
+					threadTs: getThreadAnchor(params.sourceMessageTs, params.sourceThreadTs),
+				});
+			}
+		};
+
+		const showLeaveConfirmation = async (params: {
+			userDbId: number;
+			slackUserId: string;
+			channelId: string;
+			sourceMessageTs: string;
+			sourceThreadTs?: string;
+			dates: string[];
+			leaveType: LeaveType;
+			startTime?: string;
+			endTime?: string;
+			category: LeaveCategory;
+			reason: string;
+			replaceMessageTs?: string;
+		}) => {
+			const threadAnchor = getThreadAnchor(params.sourceMessageTs, params.sourceThreadTs);
+			await supersedePendingActionsForThread(params.userDbId, params.channelId, threadAnchor, params.replaceMessageTs);
+
+			const existingRecords = getLeaveRecordsByUserAndDates(this.db, params.userDbId, params.dates);
+			const hasConflict = existingRecords.length > 0;
+			logLeave("checked existing leave records", {
+				userDbId: params.userDbId,
+				channelId: params.channelId,
+				requestedDates: params.dates,
+				hasConflict,
+				existingRecordDates: existingRecords.map((record) => record.date),
+			});
+
+			const action = createPendingAction(this.db, {
+				userId: params.userDbId,
+				actionType: "create_leave",
+				payload: {
+					dates: params.dates,
+					leaveType: params.leaveType,
+					startTime: params.startTime,
+					endTime: params.endTime,
+					category: params.category,
+					reason: params.reason,
+				},
+				slackMessageTs: params.sourceMessageTs,
+				slackChannelId: params.channelId,
+				slackThreadTs: params.sourceThreadTs,
+				expiresAt: getFutureExpiry(),
+			});
+			logLeave("created pending leave action", {
+				actionId: action.id,
+				userDbId: params.userDbId,
+				userId: params.slackUserId,
+				channelId: params.channelId,
+				messageTs: params.sourceMessageTs,
+				threadTs: params.sourceThreadTs ?? null,
+				payload: JSON.parse(action.payload),
+				expiresAt: action.expires_at,
+			});
+
+			const blocks = buildConfirmationBlocks(
+				toLeaveDates(params.dates, params.leaveType, params.category, params.startTime, params.endTime),
+				action.id,
+				hasConflict,
+			);
+			if (params.replaceMessageTs) {
+				updatePendingActionBotMessageTs(this.db, action.id, params.replaceMessageTs);
+				await ctx.slack.updateMessage(params.channelId, params.replaceMessageTs, {
+					text: "📅 Leave request ready for confirmation.",
+					blocks,
+				});
+				logLeave("updated leave option message to confirmation prompt", {
+					actionId: action.id,
+					channelId: params.channelId,
+					botMessageTs: params.replaceMessageTs,
+				});
+				return;
+			}
+
+			const sent = await ctx.slack.postMessage(params.channelId, {
+				text: "📅 Leave request ready for confirmation.",
+				blocks,
+				threadTs: threadAnchor,
+			});
+			updatePendingActionBotMessageTs(this.db, action.id, sent.ts);
+			logLeave("posted leave confirmation message", {
+				actionId: action.id,
+				channelId: params.channelId,
+				botMessageTs: sent.ts,
+				threadTs: threadAnchor,
+			});
+		};
+
+		const showCancellationConfirmation = async (params: {
+			userDbId: number;
+			slackUserId: string;
+			channelId: string;
+			sourceMessageTs: string;
+			sourceThreadTs?: string;
+			dates: string[];
+			replaceMessageTs?: string;
+		}) => {
+			const action = createPendingAction(this.db, {
+				userId: params.userDbId,
+				actionType: "cancel_leave",
+				payload: { dates: params.dates },
+				slackMessageTs: params.sourceMessageTs,
+				slackChannelId: params.channelId,
+				slackThreadTs: params.sourceThreadTs,
+				expiresAt: getFutureExpiry(),
+			});
+			logLeave("created pending cancellation action", {
+				actionId: action.id,
+				userDbId: params.userDbId,
+				userId: params.slackUserId,
+				dates: params.dates,
+				channelId: params.channelId,
+				messageTs: params.sourceMessageTs,
+				threadTs: params.sourceThreadTs ?? null,
+				expiresAt: action.expires_at,
+			});
+
+			const blocks = buildCancellationConfirmationBlocks(
+				params.dates.map((date) => ({ date, type: "full", category: "vacation" })),
+				action.id,
+			);
+			if (params.replaceMessageTs) {
+				updatePendingActionBotMessageTs(this.db, action.id, params.replaceMessageTs);
+				await ctx.slack.updateMessage(params.channelId, params.replaceMessageTs, {
+					text: "🔄 Leave cancellation ready for confirmation.",
+					blocks,
+				});
+				logLeave("updated cancellation option message to confirmation prompt", {
+					actionId: action.id,
+					channelId: params.channelId,
+					botMessageTs: params.replaceMessageTs,
+				});
+				return;
+			}
+
+			const sent = await ctx.slack.postMessage(params.channelId, {
+				text: "🔄 Leave cancellation ready for confirmation.",
+				blocks,
+				threadTs: getThreadAnchor(params.sourceMessageTs, params.sourceThreadTs),
+			});
+
+			updatePendingActionBotMessageTs(this.db, action.id, sent.ts);
+			logLeave("posted cancellation confirmation message", {
+				actionId: action.id,
+				channelId: params.channelId,
+				botMessageTs: sent.ts,
+				threadTs: getThreadAnchor(params.sourceMessageTs, params.sourceThreadTs),
+			});
+		};
 
 		ctx.slack.onMessage(async (msg) => {
 			if (msg.botId) {
@@ -77,10 +618,8 @@ export class LeavePlugin implements Plugin {
 				return null;
 			}
 
-			// Check for trigger keywords if it's a new message. If it's a thread reply, we might want to process it anyway
-			// to handle clarification responses.
 			const lowerText = msg.text.toLowerCase();
-			const hasKeyword = triggerKeywords.some((kw) => lowerText.includes(kw));
+			const hasKeyword = triggerKeywords.some((keyword) => lowerText.includes(keyword));
 			const isTargetChannel = msg.channelId === targetChannelId;
 			const isThreadReply = Boolean(msg.threadTs);
 			const matchedAsOooMessage = isTargetChannel && (hasKeyword || isThreadReply);
@@ -115,7 +654,6 @@ export class LeavePlugin implements Plugin {
 				return null;
 			}
 
-			// If it doesn't have a keyword and it's not a thread reply, ignore it.
 			if (!hasKeyword && !msg.threadTs) {
 				if (debugLogAllMessages) {
 					logLeave("message did not match as ooo message", {
@@ -143,7 +681,6 @@ export class LeavePlugin implements Plugin {
 				text: msg.text,
 			});
 
-			// Look up user
 			let user = getUserBySlackId(this.db, msg.userId);
 			if (!user) {
 				logLeave("user not found locally; fetching from Slack", { userId: msg.userId });
@@ -169,11 +706,12 @@ export class LeavePlugin implements Plugin {
 				});
 			}
 
-			// Include thread history if applicable
 			let threadContext = "";
 			if (msg.threadTs) {
 				const replies = await ctx.slack.getThreadReplies(msg.channelId, msg.threadTs);
-				threadContext = replies.map((r) => `${r.userId === msg.userId ? "User" : "Bot"}: ${r.text}`).join("\n");
+				threadContext = replies
+					.map((reply) => `${reply.userId === msg.userId ? "User" : "Bot"}: ${reply.text}`)
+					.join("\n");
 				logLeave("loaded thread context", {
 					channelId: msg.channelId,
 					threadTs: msg.threadTs,
@@ -181,11 +719,27 @@ export class LeavePlugin implements Plugin {
 				});
 			}
 
+			const currentDate = localDateStringInTimeZone(user.slack_timezone, new Date());
 			const systemPrompt = `You are a helpful assistant that parses leave requests and cancellations.
-Extract the leave dates, type, and category.
+Extract the leave dates, type, category, and times when relevant.
+Use these leave types:
+- full: a full-day leave
+- half_am: a morning half-day leave
+- half_pm: an afternoon half-day leave
+- specific: a leave with an explicit start and end time
+For specific leave, include both start_time and end_time in 24-hour HH:MM format.
+Never use type=specific unless both start and end time are known.
+If the user indicates a time-specific leave but one of the times is missing,
+lower confidence and explain that the exact time range is incomplete.
 If the user is cancelling leave, set is_cancellation to true.
 If the message is not a leave request or cancellation, set is_leave_request to false.
-The current date is ${new Date().toISOString().split("T")[0]}.
+Resolve relative dates like today, tomorrow, next Monday, and next week
+into concrete YYYY-MM-DD dates using the current date and the user's timezone.
+If leave type is not specified, default to full.
+If category is not specified, default to vacation unless the user clearly indicates sickness or a medical reason.
+Prefer an actionable interpretation when there is a reasonable single reading.
+Use low confidence only when you still cannot produce a safe actionable interpretation.
+The current date is ${currentDate}.
 The user's timezone is ${user.slack_timezone}.
 ${threadContext ? `Previous thread context:\n${threadContext}` : ""}`;
 
@@ -215,158 +769,221 @@ ${threadContext ? `Previous thread context:\n${threadContext}` : ""}`;
 				return null;
 			}
 
-			if (parsed.confidence === "low") {
-				logLeave("parser returned low confidence", {
-					channelId: msg.channelId,
-					userId: msg.userId,
-					ts: msg.ts,
-					ambiguityNotes: parsed.ambiguity_notes,
-					parsed,
-				});
-				return `I'm not quite sure I understood that. Could you clarify your leave request? (Note: ${parsed.ambiguity_notes})`;
-			}
-
-			// Handle cancellation
 			if (parsed.is_cancellation) {
 				if (parsed.dates.length === 0) {
-					logLeave("cancellation request needs clarification", {
+					const cancelableRecords = getCancelableLeaveRecordsByUser(this.db, user.id, currentDate, 5);
+					const options: InteractiveOption[] = cancelableRecords.map((record) => ({
+						text: `Cancel ${formatLeaveDateLabel(record.date)}`,
+						value: encodeSelectionPayload({
+							kind: "cancel",
+							dates: [record.date],
+							sourceMessageTs: msg.ts,
+							sourceThreadTs: msg.threadTs,
+						}),
+						actionId: "leave_select_cancel_option",
+						style: "danger",
+					}));
+					options.push({
+						text: "✗ Keep everything",
+						value: encodeSelectionPayload({ kind: "dismiss", message: "✅ Kept leave as is." }),
+						actionId: "leave_dismiss_option",
+					});
+
+					const blocks =
+						cancelableRecords.length > 0
+							? buildCancellationSelectionBlocks(options)
+							: buildInteractiveChoiceBlocks(
+									[
+										"🔄 I couldn't identify a specific leave entry to cancel,",
+										"and there are no recent leave records available to select.",
+									].join(" "),
+									options,
+								);
+
+					await ctx.slack.postMessage(msg.channelId, {
+						text: "🔄 Select a leave entry to cancel.",
+						blocks,
+						threadTs: getThreadAnchor(msg.ts, msg.threadTs),
+					});
+					logLeave("presented cancellation options", {
 						channelId: msg.channelId,
 						userId: msg.userId,
 						ts: msg.ts,
-						threadTs: msg.threadTs ?? msg.ts,
-					});
-					await ctx.slack.postMessage(msg.channelId, {
-						blocks: buildCancellationClarificationBlocks(),
-						threadTs: msg.threadTs || msg.ts,
+						optionCount: options.length,
 					});
 					return null;
 				}
 
-				// We have dates to cancel
-				const dates = parsed.dates.map((d) => d.date);
-				const action = createPendingAction(this.db, {
-					userId: user.id,
-					actionType: "cancel_leave",
-					payload: { dates },
-					slackMessageTs: msg.ts,
-					slackChannelId: msg.channelId,
-					slackThreadTs: msg.threadTs,
-					expiresAt: getFutureExpiry(),
-				});
-				logLeave("created pending cancellation action", {
-					actionId: action.id,
+				await showCancellationConfirmation({
 					userDbId: user.id,
-					userId: msg.userId,
-					dates,
+					slackUserId: msg.userId,
 					channelId: msg.channelId,
-					messageTs: msg.ts,
-					threadTs: msg.threadTs ?? null,
-					expiresAt: action.expires_at,
-				});
-
-				const sent = await ctx.slack.postMessage(msg.channelId, {
-					blocks: buildCancellationConfirmationBlocks(parsed.dates, action.id),
-					threadTs: msg.threadTs || msg.ts,
-				});
-
-				updatePendingActionBotMessageTs(this.db, action.id, sent.ts);
-				logLeave("posted cancellation confirmation message", {
-					actionId: action.id,
-					channelId: msg.channelId,
-					botMessageTs: sent.ts,
-					threadTs: msg.threadTs ?? msg.ts,
+					sourceMessageTs: msg.ts,
+					sourceThreadTs: msg.threadTs,
+					dates: parsed.dates.map((date) => date.date),
 				});
 				return null;
 			}
 
-			// Handle leave request
-			if (parsed.dates.length === 0) {
-				logLeave("leave request had no parsed dates", {
+			if (
+				parsed.confidence === "low" ||
+				parsed.dates.length === 0 ||
+				isSpecificLeaveMissingTime(parsed.dates[0]?.type, parsed.dates[0]?.start_time, parsed.dates[0]?.end_time)
+			) {
+				if (parsed.confidence === "low") {
+					logLeave("parser returned low confidence", {
+						channelId: msg.channelId,
+						userId: msg.userId,
+						ts: msg.ts,
+						ambiguityNotes: parsed.ambiguity_notes,
+						parsed,
+					});
+				} else {
+					logLeave("leave request had no parsed dates", {
+						channelId: msg.channelId,
+						userId: msg.userId,
+						ts: msg.ts,
+						parsed,
+					});
+				}
+
+				const options = buildCreateSelectionOptions(msg.text, parsed, user.slack_timezone, msg.ts, msg.threadTs);
+				await presentLeaveOptions({
+					channelId: msg.channelId,
+					sourceMessageTs: msg.ts,
+					sourceThreadTs: msg.threadTs,
+					messageText: msg.text,
+					parsed,
+					timeZone: user.slack_timezone,
+				});
+				logLeave("presented leave options instead of asking for clarification", {
 					channelId: msg.channelId,
 					userId: msg.userId,
 					ts: msg.ts,
-					parsed,
+					optionCount: options.length,
 				});
-				return "I understood this is a leave request, but couldn't find specific dates. Could you clarify?";
+				return null;
 			}
 
-			// Supersede existing pending actions in this thread
-			if (msg.threadTs) {
-				const existing = getPendingActionsForThread(this.db, user.id, msg.channelId, msg.threadTs);
-				if (existing.length > 0) {
-					logLeave("superseding existing pending actions in thread", {
-						userDbId: user.id,
-						channelId: msg.channelId,
-						threadTs: msg.threadTs,
-						actionIds: existing.map((act) => act.id),
-					});
-				}
-				for (const act of existing) {
-					updatePendingActionStatus(this.db, act.id, "expired");
-					if (act.slack_bot_message_ts) {
-						await ctx.slack.updateMessage(msg.channelId, act.slack_bot_message_ts, {
-							text: "↩️ This request was superseded by a newer one below.",
-							blocks: [
-								{
-									type: "section",
-									text: { type: "mrkdwn", text: "↩️ _This request was superseded by a newer one below._" },
-								},
-							],
-						});
-					}
-				}
-			}
-
-			const dateStrings = parsed.dates.map((d) => d.date);
-			const existingRecords = getLeaveRecordsByUserAndDates(this.db, user.id, dateStrings);
-			const hasConflict = existingRecords.length > 0;
-			logLeave("checked existing leave records", {
+			await showLeaveConfirmation({
 				userDbId: user.id,
+				slackUserId: msg.userId,
 				channelId: msg.channelId,
-				requestedDates: dateStrings,
-				hasConflict,
-				existingRecordDates: existingRecords.map((record) => record.date),
-			});
-
-			const action = createPendingAction(this.db, {
-				userId: user.id,
-				actionType: "create_leave",
-				payload: {
-					dates: dateStrings,
-					leaveType: parsed.dates[0].type, // In v1 we assume all dates in a request have the same type/category
-					category: parsed.dates[0].category,
-					reason: parsed.original_text_summary,
-				},
-				slackMessageTs: msg.ts,
-				slackChannelId: msg.channelId,
-				slackThreadTs: msg.threadTs,
-				expiresAt: getFutureExpiry(),
-			});
-			logLeave("created pending leave action", {
-				actionId: action.id,
-				userDbId: user.id,
-				userId: msg.userId,
-				channelId: msg.channelId,
-				messageTs: msg.ts,
-				threadTs: msg.threadTs ?? null,
-				payload: JSON.parse(action.payload),
-				expiresAt: action.expires_at,
-			});
-
-			const blocks = buildConfirmationBlocks(parsed.dates, action.id, hasConflict);
-			const sent = await ctx.slack.postMessage(msg.channelId, {
-				blocks,
-				threadTs: msg.threadTs || msg.ts,
-			});
-
-			updatePendingActionBotMessageTs(this.db, action.id, sent.ts);
-			logLeave("posted leave confirmation message", {
-				actionId: action.id,
-				channelId: msg.channelId,
-				botMessageTs: sent.ts,
-				threadTs: msg.threadTs ?? msg.ts,
+				sourceMessageTs: msg.ts,
+				sourceThreadTs: msg.threadTs,
+				dates: parsed.dates.map((date) => date.date),
+				leaveType: parsed.dates[0].type,
+				startTime: parsed.dates[0].start_time,
+				endTime: parsed.dates[0].end_time,
+				category: parsed.dates[0].category,
+				reason: parsed.original_text_summary,
 			});
 			return null;
+		});
+
+		ctx.slack.onAction(/^leave_select_create_option$/, async (event) => {
+			const payload = decodeSelectionPayload(event.value);
+			if (payload?.kind !== "create") {
+				logLeave("received invalid leave create selection payload", {
+					channelId: event.channelId,
+					userId: event.userId,
+					messageTs: event.messageTs,
+				});
+				return;
+			}
+
+			const user = getUserBySlackId(this.db, event.userId);
+			if (!user) {
+				logLeave("could not resolve user for leave create selection", {
+					channelId: event.channelId,
+					userId: event.userId,
+					messageTs: event.messageTs,
+				});
+				return;
+			}
+
+			logLeave("leave option selected", {
+				channelId: event.channelId,
+				userId: event.userId,
+				messageTs: event.messageTs,
+				dates: payload.dates,
+				leaveType: payload.leaveType,
+				startTime: payload.startTime,
+				endTime: payload.endTime,
+				category: payload.category,
+			});
+			await showLeaveConfirmation({
+				userDbId: user.id,
+				slackUserId: event.userId,
+				channelId: event.channelId,
+				sourceMessageTs: payload.sourceMessageTs,
+				sourceThreadTs: payload.sourceThreadTs,
+				dates: payload.dates,
+				leaveType: payload.leaveType,
+				startTime: payload.startTime,
+				endTime: payload.endTime,
+				category: payload.category,
+				reason: payload.reason,
+				replaceMessageTs: event.messageTs,
+			});
+		});
+
+		ctx.slack.onAction(/^leave_select_cancel_option$/, async (event) => {
+			const payload = decodeSelectionPayload(event.value);
+			if (payload?.kind !== "cancel") {
+				logLeave("received invalid leave cancel selection payload", {
+					channelId: event.channelId,
+					userId: event.userId,
+					messageTs: event.messageTs,
+				});
+				return;
+			}
+
+			const user = getUserBySlackId(this.db, event.userId);
+			if (!user) {
+				logLeave("could not resolve user for leave cancel selection", {
+					channelId: event.channelId,
+					userId: event.userId,
+					messageTs: event.messageTs,
+				});
+				return;
+			}
+
+			logLeave("leave cancellation option selected", {
+				channelId: event.channelId,
+				userId: event.userId,
+				messageTs: event.messageTs,
+				dates: payload.dates,
+			});
+			await showCancellationConfirmation({
+				userDbId: user.id,
+				slackUserId: event.userId,
+				channelId: event.channelId,
+				sourceMessageTs: payload.sourceMessageTs,
+				sourceThreadTs: payload.sourceThreadTs,
+				dates: payload.dates,
+				replaceMessageTs: event.messageTs,
+			});
+		});
+
+		ctx.slack.onAction(/^leave_dismiss_option$/, async (event) => {
+			const payload = decodeSelectionPayload(event.value);
+			const message = payload?.kind === "dismiss" ? payload.message : "✅ No changes made.";
+			logLeave("leave option flow dismissed", {
+				channelId: event.channelId,
+				userId: event.userId,
+				messageTs: event.messageTs,
+				message,
+			});
+			await ctx.slack.updateMessage(event.channelId, event.messageTs, {
+				text: message,
+				blocks: [
+					{
+						type: "section",
+						text: { type: "mrkdwn", text: `*${message}*` },
+					},
+				],
+			});
 		});
 
 		ctx.slack.onAction(/^leave_confirm$/, async (event) => {
@@ -425,7 +1042,7 @@ ${threadContext ? `Previous thread context:\n${threadContext}` : ""}`;
 				messageTs: event.messageTs,
 				threadTs: event.threadTs ?? null,
 			});
-			updatePendingActionStatus(this.db, actionId, "confirmed"); // "confirmed" means worker should process the cancellation
+			updatePendingActionStatus(this.db, actionId, "confirmed");
 			await ctx.slack.updateMessage(event.channelId, event.messageTs, {
 				text: "⏳ Processing cancellation...",
 				blocks: [

--- a/jadoo/src/plugins/leave/schema.ts
+++ b/jadoo/src/plugins/leave/schema.ts
@@ -2,9 +2,19 @@ import { Type } from "@sinclair/typebox";
 
 export const LeaveDateSchema = Type.Object({
 	date: Type.String({ description: "The date of the leave in YYYY-MM-DD format" }),
-	type: Type.Union([Type.Literal("full"), Type.Literal("half_am"), Type.Literal("half_pm")], {
-		description: "Whether the leave is for a full day, morning half, or afternoon half",
+	type: Type.Union([Type.Literal("full"), Type.Literal("half_am"), Type.Literal("half_pm"), Type.Literal("specific")], {
+		description: "Whether the leave is for a full day, morning half, afternoon half, or a time-specific interval",
 	}),
+	start_time: Type.Optional(
+		Type.String({
+			description: "Start time in 24-hour HH:MM format when the leave is time-specific",
+		}),
+	),
+	end_time: Type.Optional(
+		Type.String({
+			description: "End time in 24-hour HH:MM format when the leave is time-specific",
+		}),
+	),
 	category: Type.Union([Type.Literal("vacation"), Type.Literal("sick")], {
 		description: "The category of the leave",
 	}),

--- a/jadoo/src/services/harvest/harvest-service.ts
+++ b/jadoo/src/services/harvest/harvest-service.ts
@@ -16,8 +16,17 @@ const HARVEST_API_BASE = "https://api.harvestapp.com/v2";
 const FULL_DAY_HOURS = 8.0;
 const HALF_DAY_HOURS = 4.0;
 
-function getHours(leaveType: LeaveType): number {
-	return leaveType === "full" ? FULL_DAY_HOURS : HALF_DAY_HOURS;
+function getHours(request: CreateTimeEntryRequest): number {
+	if (request.hours !== undefined) {
+		return request.hours;
+	}
+	if (request.leaveType === "full") {
+		return FULL_DAY_HOURS;
+	}
+	if (request.leaveType === "half_am" || request.leaveType === "half_pm") {
+		return HALF_DAY_HOURS;
+	}
+	throw new Error("Time-specific leave requires explicit hours for Harvest sync");
 }
 
 function getTaskId(category: LeaveCategory, config: HarvestConfig): number {
@@ -28,7 +37,8 @@ function buildNotes(leaveType: LeaveType, category: LeaveCategory): string {
 	const categoryLabel = category === "sick" ? "Sick" : "Vacation";
 	if (leaveType === "full") return `Leave (${categoryLabel})`;
 	if (leaveType === "half_am") return `Leave - Morning (${categoryLabel})`;
-	return `Leave - Afternoon (${categoryLabel})`;
+	if (leaveType === "half_pm") return `Leave - Afternoon (${categoryLabel})`;
+	return `Leave - Time specific (${categoryLabel})`;
 }
 
 export class HarvestAPIService implements HarvestService {
@@ -46,7 +56,7 @@ export class HarvestAPIService implements HarvestService {
 	}
 
 	async createTimeEntry(request: CreateTimeEntryRequest): Promise<number> {
-		const hours = getHours(request.leaveType);
+		const hours = getHours(request);
 		const taskId = getTaskId(request.category, this.config);
 		const notes = request.notes ?? buildNotes(request.leaveType, request.category);
 

--- a/jadoo/src/worker.ts
+++ b/jadoo/src/worker.ts
@@ -33,7 +33,9 @@ import type { SlackService } from "./interfaces/slack.js";
 /** The JSON payload stored in pending_actions for create_leave. */
 export interface CreateLeavePayload {
 	dates: string[]; // YYYY-MM-DD
-	leaveType: string; // 'full' | 'half_am' | 'half_pm'
+	leaveType: string; // 'full' | 'half_am' | 'half_pm' | 'specific'
+	startTime?: string;
+	endTime?: string;
 	category: string; // 'vacation' | 'sick'
 	reason?: string;
 }
@@ -70,6 +72,160 @@ function logWorker(message: string, details?: Record<string, unknown>): void {
 
 function logWorkerError(message: string, details?: Record<string, unknown>): void {
 	console.error(`[worker] ${message}${details ? ` ${JSON.stringify(details)}` : ""}`);
+}
+
+function normalizeLeaveType(leaveType: string): LeaveType {
+	if (leaveType === "half_am" || leaveType === "half_pm" || leaveType === "specific") {
+		return leaveType;
+	}
+	return "full";
+}
+
+function formatLeaveTypeLabel(leaveType: string, startTime?: string, endTime?: string): string {
+	switch (normalizeLeaveType(leaveType)) {
+		case "full":
+			return "Full day";
+		case "half_am":
+			return "Half day (AM)";
+		case "half_pm":
+			return "Half day (PM)";
+		case "specific":
+			return startTime && endTime ? `Time specific (${startTime}-${endTime})` : "Time specific";
+	}
+}
+
+function buildCalendarSummary(displayName: string, payload: CreateLeavePayload): string {
+	const leaveLabel = formatLeaveTypeLabel(payload.leaveType, payload.startTime, payload.endTime);
+	return `${displayName} — ${payload.category} (${leaveLabel})`;
+}
+
+function buildCalendarDescription(payload: CreateLeavePayload): string | undefined {
+	const parts = [
+		`Type: ${formatLeaveTypeLabel(payload.leaveType, payload.startTime, payload.endTime)}`,
+		payload.reason ? `Reason: ${payload.reason}` : null,
+	].filter(Boolean);
+	return parts.length > 0 ? parts.join("\n") : undefined;
+}
+
+function buildHarvestNotes(payload: CreateLeavePayload): string {
+	const categoryLabel = payload.category === "sick" ? "Sick" : "Vacation";
+	const leaveLabel = formatLeaveTypeLabel(payload.leaveType, payload.startTime, payload.endTime);
+	const base = `Leave - ${leaveLabel} (${categoryLabel})`;
+	return payload.reason ? `${base} — ${payload.reason}` : base;
+}
+
+function getAllDayWindow(date: string): { start: Date; end: Date; allDay: true } {
+	const start = new Date(`${date}T00:00:00.000Z`);
+	const end = new Date(`${date}T00:00:00.000Z`);
+	end.setUTCDate(end.getUTCDate() + 1);
+	return { start, end, allDay: true };
+}
+
+function parseTimeParts(time: string): { hours: number; minutes: number } {
+	const match = /^(\d{2}):(\d{2})$/.exec(time);
+	if (!match) {
+		throw new Error(`Invalid time format: ${time}. Expected HH:MM`);
+	}
+	const hours = Number.parseInt(match[1], 10);
+	const minutes = Number.parseInt(match[2], 10);
+	if (hours > 23 || minutes > 59) {
+		throw new Error(`Invalid time value: ${time}. Expected HH:MM`);
+	}
+	return { hours, minutes };
+}
+
+function getTimeZoneParts(
+	date: Date,
+	timeZone: string,
+): {
+	year: number;
+	month: number;
+	day: number;
+	hour: number;
+	minute: number;
+	second: number;
+} {
+	const parts = new Intl.DateTimeFormat("en-CA", {
+		timeZone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		hourCycle: "h23",
+	}).formatToParts(date);
+	const values = Object.fromEntries(
+		parts.filter((part) => part.type !== "literal").map((part) => [part.type, Number.parseInt(part.value, 10)]),
+	) as Record<string, number>;
+	return {
+		year: values.year,
+		month: values.month,
+		day: values.day,
+		hour: values.hour,
+		minute: values.minute,
+		second: values.second,
+	};
+}
+
+function zonedTimeToUtc(date: string, time: string, timeZone: string): Date {
+	const [year, month, day] = date.split("-").map((value) => Number.parseInt(value, 10));
+	const { hours, minutes } = parseTimeParts(time);
+	const targetUtc = Date.UTC(year, month - 1, day, hours, minutes, 0);
+	let guess = targetUtc;
+
+	for (let attempt = 0; attempt < 3; attempt++) {
+		const actual = getTimeZoneParts(new Date(guess), timeZone);
+		const actualUtc = Date.UTC(actual.year, actual.month - 1, actual.day, actual.hour, actual.minute, actual.second);
+		const diff = actualUtc - targetUtc;
+		if (diff === 0) {
+			break;
+		}
+		guess -= diff;
+	}
+
+	return new Date(guess);
+}
+
+function getSpecificLeaveHours(payload: CreateLeavePayload): number | undefined {
+	if (normalizeLeaveType(payload.leaveType) !== "specific" || !payload.startTime || !payload.endTime) {
+		return undefined;
+	}
+	const { hours: startHours, minutes: startMinutes } = parseTimeParts(payload.startTime);
+	const { hours: endHours, minutes: endMinutes } = parseTimeParts(payload.endTime);
+	const startTotalMinutes = startHours * 60 + startMinutes;
+	const endTotalMinutes = endHours * 60 + endMinutes;
+	if (endTotalMinutes <= startTotalMinutes) {
+		throw new Error(
+			`End time must be after start time for time-specific leave (${payload.startTime}-${payload.endTime})`,
+		);
+	}
+	return Math.round(((endTotalMinutes - startTotalMinutes) / 60) * 100) / 100;
+}
+
+function shouldSyncSpecificLeaveToHarvest(hours: number | undefined, leaveType: string): boolean {
+	return normalizeLeaveType(leaveType) !== "specific" || hours === undefined || hours > 2;
+}
+
+function getCalendarWindow(
+	date: string,
+	payload: CreateLeavePayload,
+	timeZone: string,
+): { start: Date; end: Date; allDay: boolean } {
+	if (normalizeLeaveType(payload.leaveType) !== "specific") {
+		return getAllDayWindow(date);
+	}
+	if (!payload.startTime || !payload.endTime) {
+		throw new Error("Time-specific leave requires both startTime and endTime");
+	}
+	const start = zonedTimeToUtc(date, payload.startTime, timeZone);
+	const end = zonedTimeToUtc(date, payload.endTime, timeZone);
+	if (end <= start) {
+		throw new Error(
+			`End time must be after start time for time-specific leave (${payload.startTime}-${payload.endTime})`,
+		);
+	}
+	return { start, end, allDay: false };
 }
 
 // ─── Worker ─────────────────────────────────────────────
@@ -254,6 +410,8 @@ export class BackgroundWorker {
 				userDbId: user.id,
 				date,
 				leaveType: payload.leaveType,
+				startTime: payload.startTime ?? null,
+				endTime: payload.endTime ?? null,
 				category: payload.category,
 			});
 
@@ -262,6 +420,8 @@ export class BackgroundWorker {
 				userId: user.id,
 				date,
 				leaveType: payload.leaveType,
+				startTime: payload.startTime ?? null,
+				endTime: payload.endTime ?? null,
 				leaveCategory: payload.category,
 				slackMessageTs: action.slack_message_ts,
 				slackChannelId: action.slack_channel_id,
@@ -278,26 +438,21 @@ export class BackgroundWorker {
 			let stage: LeaveProcessingFailure["stage"] = "calendar";
 			try {
 				// Sync to Calendar
-				const isFullDayLeave = payload.leaveType === "full";
-				const start = new Date(`${date}T00:00:00`);
-				const end = isFullDayLeave ? new Date(`${date}T00:00:00`) : new Date(`${date}T23:59:59`);
-				if (isFullDayLeave) {
-					end.setDate(end.getDate() + 1);
-				}
+				const { start, end, allDay } = getCalendarWindow(date, payload, user.slack_timezone);
 				logWorker("creating calendar event", {
 					actionId: action.id,
 					recordId: record.id,
 					date,
 					start: start.toISOString(),
 					end: end.toISOString(),
-					allDay: isFullDayLeave,
+					allDay,
 				});
 				const calEvent = await this.calendar.createEvent({
-					summary: `${user.slack_display_name} — ${payload.category} (${payload.leaveType})`,
-					description: payload.reason,
+					summary: buildCalendarSummary(user.slack_display_name, payload),
+					description: buildCalendarDescription(payload),
 					start,
 					end,
-					allDay: isFullDayLeave,
+					allDay,
 				});
 				logWorker("calendar event created", {
 					actionId: action.id,
@@ -308,29 +463,43 @@ export class BackgroundWorker {
 
 				// Sync to Harvest (only if user has a Harvest mapping)
 				let harvestEntryId: number | null = null;
+				const hours = getSpecificLeaveHours(payload);
 				if (user.harvest_user_id) {
-					stage = "harvest";
-					logWorker("creating harvest time entry", {
-						actionId: action.id,
-						recordId: record.id,
-						date,
-						harvestUserId: user.harvest_user_id,
-						leaveType: payload.leaveType,
-						category: payload.category,
-					});
-					harvestEntryId = await this.harvest.createTimeEntry({
-						harvestUserId: user.harvest_user_id,
-						date,
-						leaveType: payload.leaveType as LeaveType,
-						category: payload.category as LeaveCategory,
-						notes: payload.reason,
-					});
-					logWorker("harvest time entry created", {
-						actionId: action.id,
-						recordId: record.id,
-						date,
-						harvestEntryId,
-					});
+					if (shouldSyncSpecificLeaveToHarvest(hours, payload.leaveType)) {
+						stage = "harvest";
+						logWorker("creating harvest time entry", {
+							actionId: action.id,
+							recordId: record.id,
+							date,
+							harvestUserId: user.harvest_user_id,
+							leaveType: payload.leaveType,
+							hours: hours ?? null,
+							category: payload.category,
+						});
+						harvestEntryId = await this.harvest.createTimeEntry({
+							harvestUserId: user.harvest_user_id,
+							date,
+							leaveType: normalizeLeaveType(payload.leaveType),
+							category: payload.category as LeaveCategory,
+							hours,
+							notes: buildHarvestNotes(payload),
+						});
+						logWorker("harvest time entry created", {
+							actionId: action.id,
+							recordId: record.id,
+							date,
+							harvestEntryId,
+						});
+					} else {
+						logWorker("skipping harvest sync because time-specific leave is 2 hours or less", {
+							actionId: action.id,
+							recordId: record.id,
+							date,
+							harvestUserId: user.harvest_user_id,
+							leaveType: payload.leaveType,
+							hours,
+						});
+					}
 				} else {
 					logWorker("skipping harvest sync because user has no harvest mapping", {
 						actionId: action.id,
@@ -573,21 +742,23 @@ export class BackgroundWorker {
 		}
 
 		const dateList = payload.dates.join(", ");
+		const leaveLabel = formatLeaveTypeLabel(payload.leaveType, payload.startTime, payload.endTime);
 		logWorker("sending completion notification", {
 			actionId: action.id,
 			channelId: channel,
 			botMessageTs: ts,
 			dateList,
+			leaveLabel,
 		});
 		try {
 			await this.slack.updateMessage(channel, ts, {
-				text: `✅ Leave synced: ${dateList} (${payload.category}, ${payload.leaveType})`,
+				text: `✅ Leave synced: ${dateList} (${payload.category}, ${leaveLabel})`,
 				blocks: [
 					{
 						type: "section",
 						text: {
 							type: "mrkdwn",
-							text: `✅ *Leave synced*\n📅 ${dateList}\n📋 ${payload.category} (${payload.leaveType})`,
+							text: `✅ *Leave synced*\n📅 ${dateList}\n📋 ${payload.category} (${leaveLabel})`,
 						},
 					},
 				],
@@ -637,6 +808,7 @@ export class BackgroundWorker {
 			...uniqueFailures,
 		].join("\n");
 
+		const failureDetails = uniqueFailures.length ? `\n\n${uniqueFailures.join("\n")}` : "";
 		logWorker("sending failure notification", {
 			actionId: action.id,
 			channelId: channel,
@@ -652,7 +824,7 @@ export class BackgroundWorker {
 						type: "section",
 						text: {
 							type: "mrkdwn",
-							text: `❌ *Leave processing failed*\n${summary}\nPlease try again or contact an admin.${uniqueFailures.length ? `\n\n${uniqueFailures.join("\n")}` : ""}`,
+							text: `❌ *Leave processing failed*\n${summary}\nPlease try again or contact an admin.${failureDetails}`,
 						},
 					},
 				],

--- a/jadoo/test/db.test.ts
+++ b/jadoo/test/db.test.ts
@@ -123,14 +123,18 @@ describe("Leave Records", () => {
 		const record = createLeaveRecord(db, {
 			userId,
 			date: "2026-03-16",
-			leaveType: "full",
+			leaveType: "specific",
+			startTime: "10:00",
+			endTime: "12:30",
 			leaveCategory: "vacation",
 		});
 
 		expect(record.id).toBeGreaterThan(0);
 		expect(record.user_id).toBe(userId);
 		expect(record.date).toBe("2026-03-16");
-		expect(record.leave_type).toBe("full");
+		expect(record.leave_type).toBe("specific");
+		expect(record.start_time).toBe("10:00");
+		expect(record.end_time).toBe("12:30");
 		expect(record.leave_category).toBe("vacation");
 		expect(record.status).toBe("pending");
 	});
@@ -146,11 +150,15 @@ describe("Leave Records", () => {
 		const upserted = upsertLeaveRecord(db, {
 			userId,
 			date: "2026-03-16",
-			leaveType: "half_am",
+			leaveType: "specific",
+			startTime: "09:00",
+			endTime: "11:00",
 			leaveCategory: "sick",
 		});
 
-		expect(upserted.leave_type).toBe("half_am");
+		expect(upserted.leave_type).toBe("specific");
+		expect(upserted.start_time).toBe("09:00");
+		expect(upserted.end_time).toBe("11:00");
 		expect(upserted.leave_category).toBe("sick");
 		expect(upserted.status).toBe("confirmed");
 	});
@@ -380,10 +388,11 @@ describe("Migrations", () => {
 		const applied = db
 			.query<{ name: string; hash: string }, []>("SELECT name, hash FROM schema_migrations ORDER BY name")
 			.all();
-		expect(applied.length).toBeGreaterThanOrEqual(3);
+		expect(applied.length).toBeGreaterThanOrEqual(4);
 		expect(applied[0].name).toBe("001_create_users.sql");
 		expect(applied[1].name).toBe("002_create_leave_records.sql");
 		expect(applied[2].name).toBe("003_create_pending_actions.sql");
+		expect(applied[3].name).toBe("004_add_leave_record_time_fields.sql");
 		// Hashes should be non-empty SHA256
 		expect(applied[0].hash.length).toBe(64);
 	});
@@ -392,6 +401,6 @@ describe("Migrations", () => {
 		// Run migrations again — should be a no-op
 		runMigrations(db, "./migrations");
 		const applied = db.query<{ name: string }, []>("SELECT name FROM schema_migrations").all();
-		expect(applied).toHaveLength(3);
+		expect(applied).toHaveLength(4);
 	});
 });

--- a/jadoo/test/leave-plugin.test.ts
+++ b/jadoo/test/leave-plugin.test.ts
@@ -1,0 +1,222 @@
+import type { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	createLeaveRecord,
+	createUser,
+	getPendingActionsByStatus,
+	openDatabase,
+	runMigrations,
+} from "../src/db/index.js";
+import type { BotContext } from "../src/interfaces/plugin.js";
+import { LeavePlugin } from "../src/plugins/leave/index.js";
+import { MockAIService, MockCalendarService, MockHarvestService, MockSlackService } from "./mocks.js";
+
+let db: Database;
+let ai: MockAIService;
+let slack: MockSlackService;
+let ctx: BotContext;
+
+function getActionButtons(postedMessage: (typeof slack.postedMessages)[number]) {
+	return (postedMessage.options.blocks ?? []).flatMap((block) => {
+		if ((block as { type?: string }).type !== "actions") return [];
+		return ((block as { elements?: unknown[] }).elements ?? []) as Array<{
+			action_id?: string;
+			value?: string;
+			text?: { text?: string };
+		}>;
+	});
+}
+
+beforeEach(() => {
+	db = openDatabase({ dbPath: ":memory:" });
+	runMigrations(db, "./migrations");
+	ai = new MockAIService();
+	slack = new MockSlackService();
+	ctx = {
+		ai,
+		calendar: new MockCalendarService(),
+		harvest: new MockHarvestService(),
+		slack,
+	};
+
+	slack.addUser({
+		userId: "U_NEENA",
+		displayName: "neena",
+		email: "neena@example.com",
+		timezone: "Asia/Kolkata",
+		isBot: false,
+	});
+});
+
+describe("LeavePlugin", () => {
+	it("uses button-based options instead of asking for clarification on low-confidence leave messages", async () => {
+		ai.structuredResponses.push({
+			is_leave_request: true,
+			is_cancellation: false,
+			confidence: "low",
+			dates: [],
+			original_text_summary: "I will take the day off tomorrow.",
+			ambiguity_notes: "Tomorrow can be inferred, but the parser was unsure.",
+		});
+
+		const plugin = new LeavePlugin(db);
+		await plugin.init(ctx, { channelId: "C_LEAVE", keywords: "leave,off" });
+
+		const replies = await slack.simulateMessage({
+			text: "I will take the day off tomorrow.",
+			userId: "U_NEENA",
+			channelId: "C_LEAVE",
+			ts: "msg-1",
+		});
+
+		expect(replies).toEqual([null]);
+		expect(slack.postedMessages).toHaveLength(1);
+
+		const buttons = getActionButtons(slack.postedMessages[0]);
+		expect(buttons.some((button) => button.action_id === "leave_select_create_option")).toBe(true);
+		expect(buttons.some((button) => button.action_id === "leave_dismiss_option")).toBe(true);
+
+		const createButton = buttons.find((button) => button.action_id === "leave_select_create_option");
+		expect(createButton?.value).toBeTruthy();
+
+		await slack.simulateAction({
+			actionId: "leave_select_create_option",
+			value: createButton?.value ?? "",
+			userId: "U_NEENA",
+			channelId: "C_LEAVE",
+			messageTs: slack.postedMessages[0].ts,
+			threadTs: "msg-1",
+		});
+
+		expect(slack.updatedMessages).toHaveLength(1);
+		const updatedBlocks = slack.updatedMessages[0].options.blocks ?? [];
+		const updatedButtons = updatedBlocks.flatMap((block) => {
+			if ((block as { type?: string }).type !== "actions") return [];
+			return ((block as { elements?: unknown[] }).elements ?? []) as Array<{ action_id?: string }>;
+		});
+		expect(updatedButtons.some((button) => button.action_id === "leave_confirm")).toBe(true);
+
+		const pending = getPendingActionsByStatus(db, "pending");
+		expect(pending).toHaveLength(1);
+		expect(pending[0].action_type).toBe("create_leave");
+		expect(pending[0].payload).toContain("tomorrow");
+	});
+
+	it("uses button-based options when a time-specific leave is missing an end time", async () => {
+		ai.structuredResponses.push({
+			is_leave_request: true,
+			is_cancellation: false,
+			confidence: "low",
+			dates: [
+				{
+					date: "2026-06-12",
+					type: "specific",
+					start_time: "10:00",
+					category: "vacation",
+				},
+			],
+			original_text_summary: "I need leave on June 12 from 10:00.",
+			ambiguity_notes: "End time is missing.",
+		});
+
+		const plugin = new LeavePlugin(db);
+		await plugin.init(ctx, { channelId: "C_LEAVE", keywords: "leave,off" });
+
+		const replies = await slack.simulateMessage({
+			text: "I need leave on June 12 from 10:00.",
+			userId: "U_NEENA",
+			channelId: "C_LEAVE",
+			ts: "msg-specific-missing-end",
+		});
+
+		expect(replies).toEqual([null]);
+		expect(slack.postedMessages).toHaveLength(1);
+
+		const buttons = getActionButtons(slack.postedMessages[0]);
+		expect(buttons.some((button) => button.action_id === "leave_select_create_option")).toBe(true);
+		expect(buttons.some((button) => button.action_id === "leave_dismiss_option")).toBe(true);
+
+		const createButton = buttons.find((button) => button.action_id === "leave_select_create_option");
+		expect(createButton?.value).toContain('"endTime"');
+
+		await slack.simulateAction({
+			actionId: "leave_select_create_option",
+			value: createButton?.value ?? "",
+			userId: "U_NEENA",
+			channelId: "C_LEAVE",
+			messageTs: slack.postedMessages[0].ts,
+			threadTs: "msg-specific-missing-end",
+		});
+
+		expect(slack.updatedMessages).toHaveLength(1);
+		const updatedBlocks = slack.updatedMessages[0].options.blocks ?? [];
+		const updatedButtons = updatedBlocks.flatMap((block) => {
+			if ((block as { type?: string }).type !== "actions") return [];
+			return ((block as { elements?: unknown[] }).elements ?? []) as Array<{ action_id?: string }>;
+		});
+		expect(updatedButtons.some((button) => button.action_id === "leave_confirm")).toBe(true);
+		expect(getPendingActionsByStatus(db, "pending")).toHaveLength(1);
+	});
+
+	it("uses button-based cancellation choices instead of asking for thread replies", async () => {
+		const user = createUser(db, {
+			slackUserId: "U_NEENA",
+			slackDisplayName: "neena",
+			email: "neena@example.com",
+			slackTimezone: "Asia/Kolkata",
+		});
+		createLeaveRecord(db, {
+			userId: user.id,
+			date: "2026-06-12",
+			leaveType: "full",
+			leaveCategory: "vacation",
+			status: "completed",
+		});
+
+		ai.structuredResponses.push({
+			is_leave_request: false,
+			is_cancellation: true,
+			confidence: "high",
+			dates: [],
+			original_text_summary: "cancel my leave",
+			ambiguity_notes: "",
+		});
+
+		const plugin = new LeavePlugin(db);
+		await plugin.init(ctx, { channelId: "C_LEAVE", keywords: "leave,cancel" });
+
+		const replies = await slack.simulateMessage({
+			text: "cancel my leave",
+			userId: "U_NEENA",
+			channelId: "C_LEAVE",
+			ts: "msg-2",
+		});
+
+		expect(replies).toEqual([null]);
+		expect(slack.postedMessages).toHaveLength(1);
+
+		const buttons = getActionButtons(slack.postedMessages[0]);
+		expect(buttons.some((button) => button.action_id === "leave_select_cancel_option")).toBe(true);
+		expect(buttons.some((button) => button.action_id === "leave_dismiss_option")).toBe(true);
+
+		const cancelButton = buttons.find((button) => button.action_id === "leave_select_cancel_option");
+		expect(cancelButton?.value).toBeTruthy();
+
+		await slack.simulateAction({
+			actionId: "leave_select_cancel_option",
+			value: cancelButton?.value ?? "",
+			userId: "U_NEENA",
+			channelId: "C_LEAVE",
+			messageTs: slack.postedMessages[0].ts,
+			threadTs: "msg-2",
+		});
+
+		expect(slack.updatedMessages).toHaveLength(1);
+		const updatedBlocks = slack.updatedMessages[0].options.blocks ?? [];
+		const updatedButtons = updatedBlocks.flatMap((block) => {
+			if ((block as { type?: string }).type !== "actions") return [];
+			return ((block as { elements?: unknown[] }).elements ?? []) as Array<{ action_id?: string }>;
+		});
+		expect(updatedButtons.some((button) => button.action_id === "leave_confirm_cancel")).toBe(true);
+	});
+});

--- a/jadoo/test/worker.test.ts
+++ b/jadoo/test/worker.test.ts
@@ -125,6 +125,69 @@ describe("processTick — create_leave", () => {
 		expect(getLeaveRecordsByStatus(db, "completed")).toHaveLength(3);
 	});
 
+	it("creates time-specific leave as a timed calendar event and logs exact Harvest hours when longer than 2 hours", async () => {
+		const action = createPendingAction(db, {
+			userId: user.id,
+			actionType: "create_leave",
+			payload: {
+				dates: ["2026-04-01"],
+				leaveType: "specific",
+				startTime: "10:00",
+				endTime: "12:30",
+				category: "vacation",
+				reason: "Doctor appointment",
+			},
+			slackChannelId: "C1",
+			expiresAt: futureExpiry(),
+		});
+		updatePendingActionBotMessageTs(db, action.id, "bot-msg-specific");
+		updatePendingActionStatus(db, action.id, "confirmed");
+
+		worker = new BackgroundWorker(deps(), { processIntervalMs: 999999, expiryIntervalMs: 999999 });
+		await worker.processTick();
+
+		expect(getPendingActionById(db, action.id)?.status).toBe("completed");
+		expect(calendar.createdEvents).toHaveLength(1);
+		expect(calendar.createdEvents[0].allDay).toBe(false);
+		expect(calendar.createdEvents[0].summary).toContain("Time specific");
+		expect(calendar.createdEvents[0].start.toISOString()).toBe("2026-04-01T04:30:00.000Z");
+		expect(calendar.createdEvents[0].end.toISOString()).toBe("2026-04-01T07:00:00.000Z");
+		expect(harvest.createdEntries).toHaveLength(1);
+		expect(harvest.createdEntries[0].hours).toBe(2.5);
+		expect(harvest.createdEntries[0].notes).toContain("10:00-12:30");
+	});
+
+	it("does not create a Harvest entry for time-specific leave of 2 hours or less", async () => {
+		const action = createPendingAction(db, {
+			userId: user.id,
+			actionType: "create_leave",
+			payload: {
+				dates: ["2026-04-01"],
+				leaveType: "specific",
+				startTime: "10:00",
+				endTime: "12:00",
+				category: "vacation",
+				reason: "Bank work",
+			},
+			slackChannelId: "C1",
+			expiresAt: futureExpiry(),
+		});
+		updatePendingActionBotMessageTs(db, action.id, "bot-msg-short-specific");
+		updatePendingActionStatus(db, action.id, "confirmed");
+
+		worker = new BackgroundWorker(deps(), { processIntervalMs: 999999, expiryIntervalMs: 999999 });
+		await worker.processTick();
+
+		expect(getPendingActionById(db, action.id)?.status).toBe("completed");
+		expect(calendar.createdEvents).toHaveLength(1);
+		expect(calendar.createdEvents[0].allDay).toBe(false);
+		expect(harvest.createdEntries).toHaveLength(0);
+
+		const records = getLeaveRecordsByStatus(db, "completed");
+		expect(records).toHaveLength(1);
+		expect(records[0].harvest_entry_id).toBeNull();
+	});
+
 	it("skips Harvest when user has no harvest_user_id", async () => {
 		const noHarvestUser = createUser(db, {
 			slackUserId: "U_BOB",
@@ -261,7 +324,8 @@ describe("processTick — create_leave", () => {
 		expect(getPendingActionById(db, a2.id)?.status).toBe("completed");
 		expect(calendar.createdEvents).toHaveLength(2);
 		expect(calendar.createdEvents[0].allDay).toBe(true);
-		expect(calendar.createdEvents[1].allDay).toBeFalsy();
+		expect(calendar.createdEvents[1].allDay).toBe(true);
+		expect(calendar.createdEvents[1].summary).toContain("Half day (AM)");
 		expect(harvest.createdEntries).toHaveLength(2);
 	});
 });


### PR DESCRIPTION
## Summary
- add time-specific leave support across parsing, storage, worker sync, and Harvest handling
- replace text-based leave clarifications with Slack button flows for ambiguous leave and cancellation requests
- add coverage for time-specific leave processing and button-driven leave resolution

## Testing
- ~/.bun/bin/bun test test/*.test.ts

## Notes
- no package version bump or release was needed because `jadoo` is a private package