### PR TITLE
Jadoo: restore original migration 002 hash

### DIFF
--- a/jadoo/AGENTS.md
+++ b/jadoo/AGENTS.md
@@ -30,3 +30,4 @@ If you change migrations, parsing, worker logic, or Slack interaction flows, mak
 
 - Prefer Slack Block Kit buttons for ambiguous leave flows rather than asking users for open-ended follow-up text.
 - Keep worker, parser schema, persistence, and tests aligned when adding new leave types or payload fields.
+- Do not edit already-applied migration files to update comments or documentation. Document schema behavior in `README.md` or `docs/leave-data-model.md`, and use a new migration for real schema changes.

--- a/jadoo/README.md
+++ b/jadoo/README.md
@@ -129,6 +129,7 @@ SQLite via `bun:sqlite`. Three tables:
 - **users** — Slack ↔ Harvest ↔ email mapping, timezone
 - **leave_records** — date, type (full/half/time-specific), optional start/end time,
   category (vacation/sick), sync status, calendar/harvest IDs
+  - See `docs/leave-data-model.md` for the canonical leave-type documentation.
 - **pending_actions** — confirmation flow state machine with expiry, JSON payload, thread context
 
 Typed repository functions in `src/db/` — no ORM, plain SQL queries with TypeScript interfaces.

--- a/jadoo/docs/leave-data-model.md
+++ b/jadoo/docs/leave-data-model.md
@@ -1,0 +1,25 @@
+# Leave data model
+
+Jadoo models leave in `leave_records` with these leave types:
+
+- `full` — full-day leave
+- `half_am` — first half of the day
+- `half_pm` — second half of the day
+- `specific` — a time-specific leave interval with `start_time` and `end_time`
+
+Additional fields:
+
+- `date` — leave date in `YYYY-MM-DD`
+- `start_time` / `end_time` — optional `HH:MM` fields used for `specific` leave
+- `leave_category` — currently `vacation` or `sick`
+
+## Migration note
+
+Do **not** edit previously applied migration files just to update comments or documentation.
+
+`litem8` hashes migration files, so changing even a comment in an already-run migration can break production startup with a hash mismatch.
+
+Instead:
+
+- add a new migration for schema changes
+- document the updated data model here or in `README.md`

--- a/jadoo/migrations/002_create_leave_records.sql
+++ b/jadoo/migrations/002_create_leave_records.sql
@@ -1,5 +1,5 @@
 -- Leave records: one row per user per leave day
--- leave_type: 'full' | 'half_am' | 'half_pm' | 'specific'
+-- leave_type: 'full' | 'half_am' | 'half_pm'
 -- leave_category: 'vacation' | 'sick'
 -- status: 'pending' | 'confirmed' | 'completed' | 'failed' | 'cancelled'
 CREATE TABLE leave_records (


### PR DESCRIPTION
## Summary
- restore `jadoo/migrations/002_create_leave_records.sql` to its original content
- keep the time-specific leave schema change in `004_add_leave_record_time_fields.sql`
- fix production startup failure caused by litem8 hash mismatch on an already-applied migration

## Why
`002_create_leave_records.sql` was edited after it had already been applied in production. Litem8 correctly refuses to start when a previously-run migration file changes, even if the change is only in a comment.

## Testing
- `cd jadoo && ~/.bun/bin/bun test test/*.test.ts`
- `cd jadoo && ~/.bun/bin/bun x biome check .`