### PR TITLE
Jadoo: add one-hour undo button after leave sync

### DIFF
--- a/jadoo/README.md
+++ b/jadoo/README.md
@@ -131,6 +131,7 @@ SQLite via `bun:sqlite`. Three tables:
   category (vacation/sick), sync status, calendar/harvest IDs
   - See `docs/leave-data-model.md` for the canonical leave-type documentation.
 - **pending_actions** — confirmation flow state machine with expiry, JSON payload, thread context
+  - also used for temporary post-sync undo actions (currently 1 hour)
 
 Typed repository functions in `src/db/` — no ORM, plain SQL queries with TypeScript interfaces.
 

--- a/jadoo/src/plugins/leave/blocks.ts
+++ b/jadoo/src/plugins/leave/blocks.ts
@@ -40,6 +40,13 @@ export function buildInteractiveChoiceBlocks(text: string, options: InteractiveO
 		},
 	];
 
+	const actionIdCounts = new Map<string, number>();
+	const uniquifyActionId = (actionId: string): string => {
+		const count = (actionIdCounts.get(actionId) ?? 0) + 1;
+		actionIdCounts.set(actionId, count);
+		return count === 1 ? actionId : `${actionId}_${count}`;
+	};
+
 	for (const optionGroup of chunk(options, 5)) {
 		blocks.push({
 			type: "actions",
@@ -51,7 +58,7 @@ export function buildInteractiveChoiceBlocks(text: string, options: InteractiveO
 					emoji: true,
 				},
 				value: option.value,
-				action_id: option.actionId,
+				action_id: uniquifyActionId(option.actionId),
 				...(option.style ? { style: option.style } : {}),
 			})),
 		});

--- a/jadoo/src/plugins/leave/index.ts
+++ b/jadoo/src/plugins/leave/index.ts
@@ -4,6 +4,7 @@ import type { PluginConfig, PluginConfigSchema } from "../../config/plugin-confi
 import { getCancelableLeaveRecordsByUser, getLeaveRecordsByUserAndDates } from "../../db/leave-records.js";
 import {
 	createPendingAction,
+	getPendingActionById,
 	getPendingActionsForThread,
 	updatePendingActionBotMessageTs,
 	updatePendingActionStatus,
@@ -884,7 +885,7 @@ ${threadContext ? `Previous thread context:\n${threadContext}` : ""}`;
 			return null;
 		});
 
-		ctx.slack.onAction(/^leave_select_create_option$/, async (event) => {
+		ctx.slack.onAction(/^leave_select_create_option(?:_\d+)?$/, async (event) => {
 			const payload = decodeSelectionPayload(event.value);
 			if (payload?.kind !== "create") {
 				logLeave("received invalid leave create selection payload", {
@@ -931,7 +932,7 @@ ${threadContext ? `Previous thread context:\n${threadContext}` : ""}`;
 			});
 		});
 
-		ctx.slack.onAction(/^leave_select_cancel_option$/, async (event) => {
+		ctx.slack.onAction(/^leave_select_cancel_option(?:_\d+)?$/, async (event) => {
 			const payload = decodeSelectionPayload(event.value);
 			if (payload?.kind !== "cancel") {
 				logLeave("received invalid leave cancel selection payload", {
@@ -1056,6 +1057,53 @@ ${threadContext ? `Previous thread context:\n${threadContext}` : ""}`;
 				],
 			});
 			logLeave("cancellation action marked confirmed", {
+				actionId,
+				channelId: event.channelId,
+				messageTs: event.messageTs,
+			});
+		});
+
+		ctx.slack.onAction(/^leave_undo$/, async (event) => {
+			const actionId = event.value;
+			const action = getPendingActionById(this.db, actionId);
+			const isExpired = action ? new Date(action.expires_at).getTime() <= Date.now() : false;
+			const payload = action ? (JSON.parse(action.payload) as { source?: string }) : null;
+			if (
+				action?.action_type !== "cancel_leave" ||
+				action.status !== "pending" ||
+				payload?.source !== "undo" ||
+				isExpired
+			) {
+				logLeave("undo click ignored because the undo action is no longer available", {
+					actionId,
+					userId: event.userId,
+					channelId: event.channelId,
+					messageTs: event.messageTs,
+					actionFound: Boolean(action),
+					actionStatus: action?.status,
+					isExpired,
+				});
+				return;
+			}
+
+			logLeave("leave undo clicked", {
+				actionId,
+				userId: event.userId,
+				channelId: event.channelId,
+				messageTs: event.messageTs,
+				threadTs: event.threadTs ?? null,
+			});
+			updatePendingActionStatus(this.db, actionId, "confirmed");
+			await ctx.slack.updateMessage(event.channelId, event.messageTs, {
+				text: "⏳ Undoing your leave...",
+				blocks: [
+					{
+						type: "section",
+						text: { type: "mrkdwn", text: "⏳ *Undoing your leave...*" },
+					},
+				],
+			});
+			logLeave("undo action marked confirmed", {
 				actionId,
 				channelId: event.channelId,
 				messageTs: event.messageTs,

--- a/jadoo/src/worker.ts
+++ b/jadoo/src/worker.ts
@@ -16,10 +16,12 @@
 import type { Database } from "bun:sqlite";
 import {
 	claimConfirmedActions,
+	createPendingAction,
 	expirePendingActions,
 	getUserById,
 	incrementLeaveRecordRetry,
 	updateLeaveRecordStatus,
+	updatePendingActionBotMessageTs,
 	updatePendingActionStatus,
 	upsertLeaveRecord,
 } from "./db/index.js";
@@ -43,6 +45,11 @@ export interface CreateLeavePayload {
 /** The JSON payload stored in pending_actions for cancel_leave. */
 export interface CancelLeavePayload {
 	dates: string[]; // YYYY-MM-DD
+	source?: "undo";
+	leaveType?: string;
+	startTime?: string;
+	endTime?: string;
+	category?: string;
 }
 
 interface LeaveProcessingFailure {
@@ -65,6 +72,7 @@ export interface WorkerConfig {
 const DEFAULT_PROCESS_INTERVAL = 5_000;
 const DEFAULT_EXPIRY_INTERVAL = 30_000;
 const DEFAULT_MAX_RETRIES = 3;
+const UNDO_EXPIRY_MS = 60 * 60 * 1000;
 
 function logWorker(message: string, details?: Record<string, unknown>): void {
 	console.log(`[worker] ${message}${details ? ` ${JSON.stringify(details)}` : ""}`);
@@ -112,6 +120,59 @@ function buildHarvestNotes(payload: CreateLeavePayload): string {
 	const leaveLabel = formatLeaveTypeLabel(payload.leaveType, payload.startTime, payload.endTime);
 	const base = `Leave - ${leaveLabel} (${categoryLabel})`;
 	return payload.reason ? `${base} — ${payload.reason}` : base;
+}
+
+function getUndoExpiry(): string {
+	return new Date(Date.now() + UNDO_EXPIRY_MS).toISOString();
+}
+
+function buildCompletedNotificationText(payload: CreateLeavePayload): string {
+	const dateList = payload.dates.join(", ");
+	const leaveLabel = formatLeaveTypeLabel(payload.leaveType, payload.startTime, payload.endTime);
+	return `✅ Leave synced: ${dateList} (${payload.category}, ${leaveLabel})`;
+}
+
+function buildCompletedNotificationBlocks(
+	payload: CreateLeavePayload,
+	options?: { undoActionId?: string; undoExpired?: boolean },
+) {
+	const dateList = payload.dates.join(", ");
+	const leaveLabel = formatLeaveTypeLabel(payload.leaveType, payload.startTime, payload.endTime);
+	const undoLine = options?.undoActionId
+		? "\n\n↩️ Undo is available for the next hour."
+		: options?.undoExpired
+			? "\n\n⌛ Undo is no longer available."
+			: "";
+	const blocks: Array<Record<string, unknown>> = [
+		{
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: `✅ *Leave synced*\n📅 ${dateList}\n📋 ${payload.category} (${leaveLabel})${undoLine}`,
+			},
+		},
+	];
+
+	if (options?.undoActionId) {
+		blocks.push({
+			type: "actions",
+			elements: [
+				{
+					type: "button",
+					text: {
+						type: "plain_text",
+						text: "↩ Undo (1 hour)",
+						emoji: true,
+					},
+					value: options.undoActionId,
+					action_id: "leave_undo",
+					style: "danger",
+				},
+			],
+		});
+	}
+
+	return blocks;
 }
 
 function getAllDayWindow(date: string): { start: Date; end: Date; allDay: true } {
@@ -743,25 +804,42 @@ export class BackgroundWorker {
 
 		const dateList = payload.dates.join(", ");
 		const leaveLabel = formatLeaveTypeLabel(payload.leaveType, payload.startTime, payload.endTime);
+		const undoAction = createPendingAction(this.db, {
+			userId: action.user_id,
+			actionType: "cancel_leave",
+			payload: {
+				dates: payload.dates,
+				source: "undo",
+				leaveType: payload.leaveType,
+				startTime: payload.startTime,
+				endTime: payload.endTime,
+				category: payload.category,
+			},
+			slackMessageTs: action.slack_message_ts,
+			slackChannelId: channel,
+			slackThreadTs: action.slack_thread_ts,
+			expiresAt: getUndoExpiry(),
+		});
+		updatePendingActionBotMessageTs(this.db, undoAction.id, ts);
+		logWorker("created undo action for completed leave", {
+			actionId: action.id,
+			undoActionId: undoAction.id,
+			channelId: channel,
+			botMessageTs: ts,
+			expiresAt: undoAction.expires_at,
+		});
 		logWorker("sending completion notification", {
 			actionId: action.id,
 			channelId: channel,
 			botMessageTs: ts,
 			dateList,
 			leaveLabel,
+			undoActionId: undoAction.id,
 		});
 		try {
 			await this.slack.updateMessage(channel, ts, {
-				text: `✅ Leave synced: ${dateList} (${payload.category}, ${leaveLabel})`,
-				blocks: [
-					{
-						type: "section",
-						text: {
-							type: "mrkdwn",
-							text: `✅ *Leave synced*\n📅 ${dateList}\n📋 ${payload.category} (${leaveLabel})`,
-						},
-					},
-				],
+				text: buildCompletedNotificationText(payload),
+				blocks: buildCompletedNotificationBlocks(payload, { undoActionId: undoAction.id }),
 			});
 		} catch (err) {
 			console.error(`[worker] failed to update Slack message for action ${action.id}: ${err}`);
@@ -847,19 +925,24 @@ export class BackgroundWorker {
 		}
 
 		const dateList = payload.dates.join(", ");
+		const isUndo = payload.source === "undo";
 		logWorker("sending cancellation notification", {
 			actionId: action.id,
 			channelId: channel,
 			botMessageTs: ts,
 			dateList,
+			isUndo,
 		});
 		try {
 			await this.slack.updateMessage(channel, ts, {
-				text: `🗑️ Leave cancelled: ${dateList}`,
+				text: isUndo ? `↩️ Leave undone: ${dateList}` : `🗑️ Leave cancelled: ${dateList}`,
 				blocks: [
 					{
 						type: "section",
-						text: { type: "mrkdwn", text: `🗑️ *Leave cancelled*\n📅 ${dateList}` },
+						text: {
+							type: "mrkdwn",
+							text: isUndo ? `↩️ *Leave undone*\n📅 ${dateList}` : `🗑️ *Leave cancelled*\n📅 ${dateList}`,
+						},
 					},
 				],
 			});
@@ -877,6 +960,33 @@ export class BackgroundWorker {
 				channelId: channel,
 				botMessageTs: ts,
 			});
+			return;
+		}
+
+		const cancelPayload =
+			action.action_type === "cancel_leave" ? (JSON.parse(action.payload) as CancelLeavePayload) : null;
+		if (cancelPayload?.source === "undo") {
+			const completedPayload: CreateLeavePayload = {
+				dates: cancelPayload.dates,
+				leaveType: cancelPayload.leaveType ?? "full",
+				startTime: cancelPayload.startTime,
+				endTime: cancelPayload.endTime,
+				category: cancelPayload.category ?? "vacation",
+			};
+			logWorker("sending undo-expired notification", {
+				actionId: action.id,
+				channelId: channel,
+				botMessageTs: ts,
+				dates: cancelPayload.dates,
+			});
+			try {
+				await this.slack.updateMessage(channel, ts, {
+					text: buildCompletedNotificationText(completedPayload),
+					blocks: buildCompletedNotificationBlocks(completedPayload, { undoExpired: true }),
+				});
+			} catch (err) {
+				console.error(`[worker] failed to update Slack message for expired action ${action.id}: ${err}`);
+			}
 			return;
 		}
 

--- a/jadoo/test/leave-plugin.test.ts
+++ b/jadoo/test/leave-plugin.test.ts
@@ -2,7 +2,9 @@ import type { Database } from "bun:sqlite";
 import { beforeEach, describe, expect, it } from "bun:test";
 import {
 	createLeaveRecord,
+	createPendingAction,
 	createUser,
+	getPendingActionById,
 	getPendingActionsByStatus,
 	openDatabase,
 	runMigrations,
@@ -73,14 +75,15 @@ describe("LeavePlugin", () => {
 		expect(slack.postedMessages).toHaveLength(1);
 
 		const buttons = getActionButtons(slack.postedMessages[0]);
-		expect(buttons.some((button) => button.action_id === "leave_select_create_option")).toBe(true);
+		expect(buttons.some((button) => button.action_id?.startsWith("leave_select_create_option"))).toBe(true);
 		expect(buttons.some((button) => button.action_id === "leave_dismiss_option")).toBe(true);
+		expect(new Set(buttons.map((button) => button.action_id)).size).toBe(buttons.length);
 
-		const createButton = buttons.find((button) => button.action_id === "leave_select_create_option");
+		const createButton = buttons.find((button) => button.action_id?.startsWith("leave_select_create_option"));
 		expect(createButton?.value).toBeTruthy();
 
 		await slack.simulateAction({
-			actionId: "leave_select_create_option",
+			actionId: createButton?.action_id ?? "leave_select_create_option",
 			value: createButton?.value ?? "",
 			userId: "U_NEENA",
 			channelId: "C_LEAVE",
@@ -133,14 +136,15 @@ describe("LeavePlugin", () => {
 		expect(slack.postedMessages).toHaveLength(1);
 
 		const buttons = getActionButtons(slack.postedMessages[0]);
-		expect(buttons.some((button) => button.action_id === "leave_select_create_option")).toBe(true);
+		expect(buttons.some((button) => button.action_id?.startsWith("leave_select_create_option"))).toBe(true);
 		expect(buttons.some((button) => button.action_id === "leave_dismiss_option")).toBe(true);
+		expect(new Set(buttons.map((button) => button.action_id)).size).toBe(buttons.length);
 
-		const createButton = buttons.find((button) => button.action_id === "leave_select_create_option");
+		const createButton = buttons.find((button) => button.action_id?.startsWith("leave_select_create_option"));
 		expect(createButton?.value).toContain('"endTime"');
 
 		await slack.simulateAction({
-			actionId: "leave_select_create_option",
+			actionId: createButton?.action_id ?? "leave_select_create_option",
 			value: createButton?.value ?? "",
 			userId: "U_NEENA",
 			channelId: "C_LEAVE",
@@ -196,14 +200,15 @@ describe("LeavePlugin", () => {
 		expect(slack.postedMessages).toHaveLength(1);
 
 		const buttons = getActionButtons(slack.postedMessages[0]);
-		expect(buttons.some((button) => button.action_id === "leave_select_cancel_option")).toBe(true);
+		expect(buttons.some((button) => button.action_id?.startsWith("leave_select_cancel_option"))).toBe(true);
 		expect(buttons.some((button) => button.action_id === "leave_dismiss_option")).toBe(true);
+		expect(new Set(buttons.map((button) => button.action_id)).size).toBe(buttons.length);
 
-		const cancelButton = buttons.find((button) => button.action_id === "leave_select_cancel_option");
+		const cancelButton = buttons.find((button) => button.action_id?.startsWith("leave_select_cancel_option"));
 		expect(cancelButton?.value).toBeTruthy();
 
 		await slack.simulateAction({
-			actionId: "leave_select_cancel_option",
+			actionId: cancelButton?.action_id ?? "leave_select_cancel_option",
 			value: cancelButton?.value ?? "",
 			userId: "U_NEENA",
 			channelId: "C_LEAVE",
@@ -218,5 +223,44 @@ describe("LeavePlugin", () => {
 			return ((block as { elements?: unknown[] }).elements ?? []) as Array<{ action_id?: string }>;
 		});
 		expect(updatedButtons.some((button) => button.action_id === "leave_confirm_cancel")).toBe(true);
+	});
+
+	it("confirms undo actions from the success message", async () => {
+		const user = createUser(db, {
+			slackUserId: "U_NEENA",
+			slackDisplayName: "neena",
+			email: "neena@example.com",
+			slackTimezone: "Asia/Kolkata",
+		});
+		const undoAction = createPendingAction(db, {
+			userId: user.id,
+			actionType: "cancel_leave",
+			payload: {
+				dates: ["2026-06-12"],
+				source: "undo",
+				leaveType: "full",
+				category: "vacation",
+			},
+			slackChannelId: "C_LEAVE",
+			slackMessageTs: "msg-3",
+			slackThreadTs: "msg-3",
+			expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+		});
+
+		const plugin = new LeavePlugin(db);
+		await plugin.init(ctx, { channelId: "C_LEAVE", keywords: "leave,cancel" });
+
+		await slack.simulateAction({
+			actionId: "leave_undo",
+			value: undoAction.id,
+			userId: "U_NEENA",
+			channelId: "C_LEAVE",
+			messageTs: "bot-msg-undo",
+			threadTs: "msg-3",
+		});
+
+		expect(getPendingActionById(db, undoAction.id)?.status).toBe("confirmed");
+		expect(slack.updatedMessages).toHaveLength(1);
+		expect(slack.updatedMessages[0].options.text).toContain("Undoing your leave");
 	});
 });

--- a/jadoo/test/worker.test.ts
+++ b/jadoo/test/worker.test.ts
@@ -5,6 +5,7 @@ import {
 	createUser,
 	getLeaveRecordsByStatus,
 	getPendingActionById,
+	getPendingActionsByStatus,
 	openDatabase,
 	runMigrations,
 	updateLeaveRecordStatus,
@@ -99,10 +100,21 @@ describe("processTick — create_leave", () => {
 		expect(records[0].calendar_event_id).toBe("mock-1");
 		expect(records[0].harvest_entry_id).toBe(1000);
 
-		// Slack message updated with success
+		// Slack message updated with success + undo button
 		expect(slack.updatedMessages).toHaveLength(1);
 		expect(slack.updatedMessages[0].options.text).toContain("✅");
 		expect(slack.updatedMessages[0].options.text).toContain("2026-04-01");
+		const blocks = slack.updatedMessages[0].options.blocks ?? [];
+		const buttons = blocks.flatMap((block) => {
+			if ((block as { type?: string }).type !== "actions") return [];
+			return ((block as { elements?: unknown[] }).elements ?? []) as Array<{ action_id?: string; value?: string }>;
+		});
+		expect(buttons.some((button) => button.action_id === "leave_undo")).toBe(true);
+
+		const pending = getPendingActionsByStatus(db, "pending");
+		expect(pending).toHaveLength(1);
+		expect(pending[0].action_type).toBe("cancel_leave");
+		expect(pending[0].payload).toContain('"source":"undo"');
 	});
 
 	it("handles multiple dates in a single action", async () => {
@@ -479,6 +491,36 @@ describe("expiryTick", () => {
 
 		expect(getPendingActionById(db, action.id)?.status).toBe("expired");
 		expect(slack.updatedMessages).toHaveLength(0);
+	});
+
+	it("removes the undo button after the undo window expires", async () => {
+		const action = createPendingAction(db, {
+			userId: user.id,
+			actionType: "cancel_leave",
+			payload: {
+				dates: ["2026-04-01"],
+				source: "undo",
+				leaveType: "full",
+				category: "vacation",
+			},
+			slackChannelId: "C1",
+			slackMessageTs: "msg-undo-1",
+			expiresAt: pastExpiry(),
+		});
+		updatePendingActionBotMessageTs(db, action.id, "bot-msg-undo-1");
+
+		worker = new BackgroundWorker(deps(), { processIntervalMs: 999999, expiryIntervalMs: 999999 });
+		await worker.expiryTick();
+
+		expect(getPendingActionById(db, action.id)?.status).toBe("expired");
+		expect(slack.updatedMessages).toHaveLength(1);
+		expect(slack.updatedMessages[0].options.text).toContain("✅ Leave synced");
+		const blocks = slack.updatedMessages[0].options.blocks ?? [];
+		const buttons = blocks.flatMap((block) => {
+			if ((block as { type?: string }).type !== "actions") return [];
+			return ((block as { elements?: unknown[] }).elements ?? []) as Array<{ action_id?: string }>;
+		});
+		expect(buttons).toHaveLength(0);
 	});
 });
 


### PR DESCRIPTION
## Summary
- add a 1-hour Undo button after leave sync completes
- wire Undo clicks into the existing cancellation worker flow
- remove the Undo button after the window expires
- fix duplicate Slack `action_id` values in interactive option messages

## Why
After a leave request is confirmed and synced, users should be able to quickly revert it without starting a new free-text cancellation flow. This also fixes the `invalid_blocks` Slack error caused by repeated action IDs in cancellation option buttons.

## Testing
- `cd jadoo && ~/.bun/bin/bun test test/*.test.ts`
- `cd jadoo && ~/.bun/bin/bun x @biomejs/biome check .`