### PR TITLE
Fix editing-in-progress Linux runtime

### DIFF
--- a/editing-in-progress/server/app/api.ts
+++ b/editing-in-progress/server/app/api.ts
@@ -138,7 +138,7 @@ export function createLocalHandler(
           "content-type": contentType,
           "cache-control": "no-store",
           "content-security-policy":
-            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self' data:",
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self' data:",
           "x-content-type-options": "nosniff",
           "referrer-policy": "no-referrer",
         },

--- a/editing-in-progress/server/app/api_test.ts
+++ b/editing-in-progress/server/app/api_test.ts
@@ -52,4 +52,13 @@ Deno.test("static index requires token while health remains public", async () =>
   );
   assertEquals(index.status, 200);
   assertEquals(index.headers.get("x-content-type-options"), "nosniff");
+  if (
+    !index.headers.get("content-security-policy")?.includes(
+      "script-src 'self' 'wasm-unsafe-eval'",
+    )
+  ) {
+    throw new Error(
+      "content security policy blocks the Automerge WebAssembly module",
+    );
+  }
 });

--- a/editing-in-progress/server/window.ts
+++ b/editing-in-progress/server/window.ts
@@ -25,7 +25,15 @@ export async function openNativeWindow(url: string): Promise<void> {
   window.setSize(1180, 800);
   window.setCenter();
   try {
-    if (!window.showWebView(url)) await window.show(url);
+    if (Deno.build.os === "linux") {
+      // GTK WebView must run on the main thread, but its synchronous first
+      // navigation blocks the loopback Deno server that supplies this page.
+      // Running it on an FFI worker avoids that deadlock but makes WebKitGTK
+      // abort during interaction, so use WebUI's browser window on Linux.
+      await window.show(url);
+    } else if (!window.showWebView(url)) {
+      await window.show(url);
+    }
     await WebUI.wait();
   } finally {
     WebUI.clean();

--- a/editing-in-progress/ui/src/index.tsx
+++ b/editing-in-progress/ui/src/index.tsx
@@ -230,19 +230,26 @@ function App() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+      if (
+        (event.metaKey || event.ctrlKey) && event.shiftKey &&
+        event.key.toLowerCase() === "k"
+      ) {
         event.preventDefault();
+        event.stopPropagation();
         setPaletteIndex(0);
         setPaletteOpen(true);
       }
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
         event.preventDefault();
+        event.stopPropagation();
         void handleSave();
       }
       if (event.key === "Escape") setPaletteOpen(false);
     };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    // Capture shortcuts before MDXEditor or the external browser handles them.
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
   }, [handleSave]);
 
   useEffect(() => () => window.clearTimeout(syncTimer.current), []);
@@ -356,7 +363,7 @@ function App() {
           </button>
           <div className="top-actions">
             <span className="shortcut">
-              {navigator.platform.includes("Mac") ? "⌘K" : "Ctrl K"}
+              {navigator.platform.includes("Mac") ? "⌘⇧K" : "Ctrl Shift K"}
             </span>
             <button
               onClick={() => void handleSave()}


### PR DESCRIPTION
## Summary
- allow Automerge WebAssembly under the local UI content security policy
- use a browser window on Linux to avoid WebKitGTK startup deadlocks and interaction crashes
- capture Ctrl-S for saving and move the file switcher to Ctrl-Shift-K

## Validation
- API tests: 2 passed
- window test: 1 passed
- UI tests: 7 passed
- Deno type checks passed