### PR TITLE
Add macOS browser fallback

### DIFF
--- a/editing-in-progress/README.md
+++ b/editing-in-progress/README.md
@@ -1,7 +1,8 @@
 # Editing in Progress
 
 A local-first collaborative Markdown editor implemented entirely in
-Deno/TypeScript. Deno-WebUI opens the loopback UI in a native WebView window.
+Deno/TypeScript. Deno-WebUI opens the loopback UI in a native WebView window,
+with the system default browser as a macOS fallback.
 
 ## Architecture
 
@@ -21,7 +22,7 @@ viewers.
 
 - Deno **2.9.4** to build and test
 - Linux: the GTK WebView runtime required by WebUI
-- macOS: WKWebView
+- macOS: WKWebView, or a default browser such as Safari as fallback
 
 The installed public command contains the Deno runtime, TypeScript application,
 and bundled UI. A checksummed WebUI native library is shipped beside it. An

--- a/editing-in-progress/scripts/build_app.ts
+++ b/editing-in-progress/scripts/build_app.ts
@@ -72,6 +72,9 @@ await Deno.mkdir(libraryDirectory, { recursive: true });
 await Deno.writeFile(`${libraryDirectory}/${target.library}`, library, {
   mode: 0o644,
 });
+const runPermission = targetName.endsWith("-linux-gnu")
+  ? ["--allow-run=firefox,google-chrome"]
+  : [];
 await run([
   Deno.execPath(),
   "compile",
@@ -81,7 +84,7 @@ await run([
   "--allow-write",
   "--allow-net",
   "--allow-env=HOME,USER,EIP_WEBUI_LIBRARY_PATH",
-  "--allow-run=firefox,google-chrome",
+  ...runPermission,
   "--allow-ffi",
   "--include",
   "ui/dist",

--- a/editing-in-progress/server/window.ts
+++ b/editing-in-progress/server/window.ts
@@ -74,8 +74,15 @@ export async function openNativeWindow(url: string): Promise<void> {
   window.setSize(1180, 800);
   window.setCenter();
   try {
-    if (!window.showWebView(url)) await window.show(url);
-    await WebUI.wait();
+    if (window.showWebView(url)) {
+      await WebUI.wait();
+    } else {
+      // Safari is not a WebUI-managed browser, but the editor only needs its
+      // authenticated loopback HTTP API. Use the macOS default browser (Safari
+      // on a stock installation) when WKWebView is unavailable.
+      WebUI.openUrl(url);
+      await waitForShutdownSignal();
+    }
   } finally {
     WebUI.clean();
   }


### PR DESCRIPTION
## Summary
- fall back to the macOS default browser when WKWebView is unavailable
- keep browser execution permissions Linux-only
- document Safari/default-browser fallback behavior

## Validation
- `deno fmt --check server/window.ts scripts/build_app.ts README.md`
- `deno task check`
- `deno test --allow-read --allow-write --allow-net --allow-env server/window_test.ts`
- `EIP_TARGET=aarch64-apple-darwin deno task build`